### PR TITLE
cmd: use AWS not Aws

### DIFF
--- a/pkg/cmd/controller/annotations.go
+++ b/pkg/cmd/controller/annotations.go
@@ -35,7 +35,7 @@ type annotationsT struct {
 	healthcheckPath *string
 	port            []*int64
 	scheme          *string
-	securityGroups  AwsStringSlice
+	securityGroups  AWSStringSlice
 	subnets         Subnets
 	successCodes    *string
 	tags            []*elbv2.Tag
@@ -218,14 +218,14 @@ func (ac *ALBController) parseSubnets(s string) (out Subnets, err error) {
 		}
 	}
 
-	sort.Sort(AwsStringSlice(out))
+	sort.Sort(AWSStringSlice(out))
 	if len(out) == 0 {
 		return nil, fmt.Errorf("unable to resolve any subnets from: %s", s)
 	}
 	return out, nil
 }
 
-func parseSecurityGroups(s string) (out AwsStringSlice, err error) {
+func parseSecurityGroups(s string) (out AWSStringSlice, err error) {
 	var names []*string
 
 	for _, sg := range stringToAwsSlice(s) {

--- a/pkg/cmd/controller/elbv2.go
+++ b/pkg/cmd/controller/elbv2.go
@@ -146,8 +146,8 @@ func (elb *ELBV2) describeTargetGroup(arn *string) (*elbv2.TargetGroup, error) {
 	return targetGroups.TargetGroups[0], nil
 }
 
-func (elb *ELBV2) describeTargetGroupTargets(arn *string) (AwsStringSlice, error) {
-	var targets AwsStringSlice
+func (elb *ELBV2) describeTargetGroupTargets(arn *string) (AWSStringSlice, error) {
+	var targets AWSStringSlice
 	targetGroupHealth, err := elbv2svc.svc.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
 		TargetGroupArn: arn,
 	})

--- a/pkg/cmd/controller/elbv2_loadbalancer.go
+++ b/pkg/cmd/controller/elbv2_loadbalancer.go
@@ -235,8 +235,8 @@ func (lb *LoadBalancer) needsModification() (LoadBalancerChange, bool) {
 		changes |= SubnetsModified
 	}
 
-	currentSecurityGroups := AwsStringSlice(lb.CurrentLoadBalancer.SecurityGroups)
-	desiredSecurityGroups := AwsStringSlice(lb.DesiredLoadBalancer.SecurityGroups)
+	currentSecurityGroups := AWSStringSlice(lb.CurrentLoadBalancer.SecurityGroups)
+	desiredSecurityGroups := AWSStringSlice(lb.DesiredLoadBalancer.SecurityGroups)
 	sort.Sort(currentSecurityGroups)
 	sort.Sort(desiredSecurityGroups)
 	if awsutil.Prettify(currentSecurityGroups) != awsutil.Prettify(desiredSecurityGroups) {

--- a/pkg/cmd/controller/elbv2_targetgroup.go
+++ b/pkg/cmd/controller/elbv2_targetgroup.go
@@ -20,8 +20,8 @@ type TargetGroup struct {
 	SvcName            string
 	CurrentTags        Tags
 	DesiredTags        Tags
-	CurrentTargets     AwsStringSlice
-	DesiredTargets     AwsStringSlice
+	CurrentTargets     AWSStringSlice
+	DesiredTargets     AWSStringSlice
 	CurrentTargetGroup *elbv2.TargetGroup
 	DesiredTargetGroup *elbv2.TargetGroup
 }

--- a/pkg/cmd/controller/util.go
+++ b/pkg/cmd/controller/util.go
@@ -14,16 +14,16 @@ import (
 
 var cache = ccache.New(ccache.Configure())
 
-type AwsStringSlice []*string
+type AWSStringSlice []*string
 type Tags []*elbv2.Tag
 type EC2Tags []*ec2.Tag
 
 type AvailabilityZones []*elbv2.AvailabilityZone
-type Subnets AwsStringSlice
+type Subnets AWSStringSlice
 
-func (n AwsStringSlice) Len() int           { return len(n) }
-func (n AwsStringSlice) Less(i, j int) bool { return *n[i] < *n[j] }
-func (n AwsStringSlice) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n AWSStringSlice) Len() int           { return len(n) }
+func (n AWSStringSlice) Less(i, j int) bool { return *n[i] < *n[j] }
+func (n AWSStringSlice) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
 
 func (n Tags) Len() int           { return len(n) }
 func (n Tags) Less(i, j int) bool { return *n[i].Key < *n[j].Key }
@@ -32,8 +32,8 @@ func (n Tags) Swap(i, j int) {
 }
 
 // GetNodes returns a list of the cluster node external ids
-func GetNodes(ac *ALBController) AwsStringSlice {
-	var result AwsStringSlice
+func GetNodes(ac *ALBController) AWSStringSlice {
+	var result AWSStringSlice
 	nodes, _ := ac.storeLister.Node.List()
 	for _, node := range nodes.Items {
 		result = append(result, aws.String(node.Spec.ExternalID))
@@ -42,7 +42,7 @@ func GetNodes(ac *ALBController) AwsStringSlice {
 	return result
 }
 
-func (a AwsStringSlice) Hash() *string {
+func (a AWSStringSlice) Hash() *string {
 	sort.Sort(a)
 	hasher := md5.New()
 	for _, str := range a {
@@ -87,7 +87,7 @@ func SortedMap(m map[string]string) Tags {
 	return t
 }
 
-func (az AvailabilityZones) AsSubnets() AwsStringSlice {
+func (az AvailabilityZones) AsSubnets() AWSStringSlice {
 	var out []*string
 	for _, a := range az {
 		out = append(out, a.SubnetId)


### PR DESCRIPTION
AWS is an acronym and should be all capitals or all lower case due to
the Go style guide.