### PR TITLE
examples: make everything generic

### DIFF
--- a/examples/2048/2048-ingress.yaml
+++ b/examples/2048/2048-ingress.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: "2048-game"
   annotations:
     alb.ingress.kubernetes.io/scheme: internal
-    alb.ingress.kubernetes.io/subnets: cs-1.preprod,cs-2.preprod,cs-3.preprod
-    alb.ingress.kubernetes.io/security-groups: preprod.onprem,preprod.cs,preprod.web
+    alb.ingress.kubernetes.io/subnets: subnet-1234
+    alb.ingress.kubernetes.io/security-groups: sg-1234
   labels:
     app: 2048-nginx-ingress
 spec:
   rules:
-  - host: 2048.tmaws.io
+  - host: 2048.example.com
     http:
       paths:
       - path: /

--- a/examples/echoservice/echoserver-ingress.yaml
+++ b/examples/echoservice/echoserver-ingress.yaml
@@ -5,12 +5,12 @@ metadata:
   namespace: echoserver
   annotations:
     alb.ingress.kubernetes.io/scheme: internal
-    alb.ingress.kubernetes.io/subnets: subnet-0d2bab64,subnet-9c569ce7
-    alb.ingress.kubernetes.io/security-groups: sg-ccaacaa5
-    alb.ingress.kubernetes.io/tags: Environment=dev1,ProductCode=PRD999,InventoryCode=echo-app
+    alb.ingress.kubernetes.io/subnets: subnet-1234
+    alb.ingress.kubernetes.io/security-groups: sg-1234
+    alb.ingress.kubernetes.io/tags: Environment=dev,Team=test
 spec:
   rules:
-  - host: aaaaaa.josh-test-dns.com
+  - host: echoserver.example.com
     http:
       paths:
       - path: /


### PR DESCRIPTION
Remove all mentions of specific domain names so that things can be
easily customized from the README.