### PR TITLE
Respect ingress.class annotations

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ metadata:
     alb.ingress.kubernetes.io/port: "8080,9000"                                                
     alb.ingress.kubernetes.io/subnets: subnet-63bf6318,subnet-0b20aa62                         
     alb.ingress.kubernetes.io/security-groups: sg-1f84f776                                     
-		kubernetes.io/ingress.class: "alb"                                                         
+    kubernetes.io/ingress.class: "alb"                                                         
 spec:                                    
 	...
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,9 +17,35 @@ You can further limit the ingresses your controller has access to. The options a
 
 ### Limiting Ingress Class
 
-_[This feature is currently being implemented]_
-
 Setting the `kubernetes.io/ingress.class` annotation allows for classification of ingress resources and is especially helpful when running multiple ingress controllers in the same cluster. See [Using Multiple Ingress Controllers](https://github.com/nginxinc/kubernetes-ingress/tree/master/examples/multiple-ingress-controllers#using-multiple-ingress-controllers) for more details.
+
+An example of the container spec portion of the controller, only listening for resources with the class "alb", would be as follows.
+
+```yaml
+spec:
+  containers:
+  - args:
+    - /server
+    - --default-backend-service=kube-system/default-http-backend
+    - --ingress-class=alb
+```
+
+Now, only ingress resources with the appropriate annotation are picked up, as seen below.
+
+```yaml
+apiVersion: extensions/v1beta1                                                                 
+kind: Ingress                                                                                  
+metadata:                                                                                      
+  name: echoserver                                                                             
+  namespace: echoserver                                                                        
+  annotations:                                                                                 
+    alb.ingress.kubernetes.io/port: "8080,9000"                                                
+    alb.ingress.kubernetes.io/subnets: subnet-63bf6318,subnet-0b20aa62                         
+    alb.ingress.kubernetes.io/security-groups: sg-1f84f776                                     
+		kubernetes.io/ingress.class: "alb"                                                         
+spec:                                    
+	...
+```
 
 ### Limiting Namespaces
 

--- a/examples/alb-ingress-controller.yaml
+++ b/examples/alb-ingress-controller.yaml
@@ -39,6 +39,10 @@ spec:
         # Limit the namespace where this ALB Ingress Controller deployment will
         # resolve ingress resources. If left commented, all namespaces are used.
         #- --watch-namespace=your-k8s-namespace
+        # Setting the ingress-class flag below will ensure that only ingress resources with the
+        # annotation kubernetes.io/ingress.class: "alb" are respected by the controller. You may
+        # choose any class you'd like for this controller to respect.
+        #- --ingress-class=alb
         env:
           # AWS region this ingress controller will operate in.
           # List of regions:

--- a/main.go
+++ b/main.go
@@ -44,8 +44,12 @@ func main() {
 	ic := ingresscontroller.NewIngressController(ac)
 	http.Handle("/metrics", promhttp.Handler())
 
-	port := "8080"
+	ac.IngressClass = ic.IngressClass()
+	if ac.IngressClass != "" {
+		log.Infof("Ingress class set to %s", "controller", ac.IngressClass)
+	}
 
+	port := "8080"
 	go http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
 	defer func() {
 		glog.Infof("Shutting down ingress controller...")


### PR DESCRIPTION
- When ingress class is present, respect the annotation and don't pick
up any resources without that class specified.
- Add docs around this functionality.

Solves #12

Ready to merge on your approval @bigkraig 