### PR TITLE
Don't attempt rule deletion when it's a default rule.

### DIFF
--- a/controller/alb/rule.go
+++ b/controller/alb/rule.go
@@ -133,6 +133,7 @@ func (r *Rule) delete(lb *LoadBalancer) error {
 	if *r.CurrentRule.IsDefault {
 		log.Debugf("Deletion hit for default rule, which is bound to the Listener. It will not be deleted from here. Rule. Rule: %s",
 			*r.IngressID, log.Prettify(r))
+		return nil
 	}
 
 	in := elbv2.DeleteRuleInput{RuleArn: r.CurrentRule.RuleArn}


### PR DESCRIPTION
Rules that are default are bound to the listener and deletion should not be attempted.

@bigkraig, I couldn't reproduce #37, but think this would fix it.

I believe the state of how the old ingress controller was creating things is different than the new so it's trying to reconcile. Nonetheless, default rule deletion attempts like that should not happen.

Let me know if this resolves #37.