### PR TITLE
config: Validate no dupe AZs in ALB

### DIFF
--- a/controller/config/annotations.go
+++ b/controller/config/annotations.go
@@ -120,7 +120,7 @@ func ParseAnnotations(annotations map[string]string) (*Annotations, error) {
 			return nil, err
 		}
 	}
-	if err := a.resolveVPC(); err != nil {
+	if err := a.resolveVPCValidateSubnets(); err != nil {
 		cache.Set(cacheKey, "error", 1*time.Hour)
 		return nil, err
 	}


### PR DESCRIPTION
- After parsing annotations, ensure no resolved subnet has a duplicate
AZ relative to other subnets.
- Resolves #45.

@bigkraig :eyes: when you can.