### PR TITLE
Respect changes in node list

### DIFF
--- a/controller/alb/targetgroup.go
+++ b/controller/alb/targetgroup.go
@@ -121,8 +121,8 @@ func (tg *TargetGroup) create(lb *LoadBalancer) error {
 		Port:                       tg.DesiredTargetGroup.Port,
 		Protocol:                   tg.DesiredTargetGroup.Protocol,
 		Name:                       tg.DesiredTargetGroup.TargetGroupName,
-		UnhealthyThresholdCount: tg.DesiredTargetGroup.UnhealthyThresholdCount,
-		VpcId: lb.CurrentLoadBalancer.VpcId,
+		UnhealthyThresholdCount:    tg.DesiredTargetGroup.UnhealthyThresholdCount,
+		VpcId:                      lb.CurrentLoadBalancer.VpcId,
 	}
 
 	o, err := awsutil.ALBsvc.AddTargetGroup(in)
@@ -232,6 +232,9 @@ func (tg *TargetGroup) needsModification() bool {
 	case awsutil.Prettify(ctg.Matcher) != awsutil.Prettify(dtg.Matcher):
 		return true
 	case *ctg.UnhealthyThresholdCount != *dtg.UnhealthyThresholdCount:
+		return true
+	case *tg.CurrentTargets.Hash() != *tg.DesiredTargets.Hash():
+		log.Infof("Found node list change. Updating target groups.", *tg.IngressID)
 		return true
 	}
 	// These fields require a rebuild and are enforced via TG name hash


### PR DESCRIPTION
- When nodes are scaled up or down, the target group(s) are updated.
- Related to #41.

Logs now display:
```
I0414 22:05:37.782265       1 log.go:48] [ALB-INGRESS] [echoserver-echoserver] [INFO]: Found node list change. Updating target groups.
I0414 22:05:37.782293       1 log.go:48] [ALB-INGRESS] [echoserver-echoserver] [INFO]: Start TargetGroup modification.
I0414 22:05:37.782306       1 log.go:48] [ALB-INGRESS] [echoserver-echoserver] [INFO]: Found node list change. Updating target groups.
I0414 22:05:38.080117       1 log.go:48] [ALB-INGRESS] [echoserver-echoserver] [INFO]: Succeeded TargetGroup modification. ARN: arn:aws:elasticloadbalancing:us-east-2:432733164488:targetgroup/dev1-30946-HTTP-58efb8e/4e0298197f75d745 | Name: dev1-30946-HTTP-58efb8e.
I0414 22:05:38.080154       1 log.go:48] [ALB-INGRESS] [echoserver-echoserver] [INFO]: Found node list change. Updating target groups.
I0414 22:05:38.080160       1 log.go:48] [ALB-INGRESS] [echoserver-echoserver] [INFO]: Start TargetGroup modification.
I0414 22:05:38.080169       1 log.go:48] [ALB-INGRESS] [echoserver-echoserver] [INFO]: Found node list change. Updating target groups.
I0414 22:05:38.273432       1 log.go:48] [ALB-INGRESS] [echoserver-echoserver] [INFO]: Succeeded TargetGroup modification. ARN: arn:aws:elasticloadbalancing:us-east-2:432733164488:targetgroup/dev1-32488-HTTP-58efb8e/bbf57409df4d2514 | Name: dev1-32488-HTTP-58efb8e.

```