### PR TITLE
Cache validation attempts

### DIFF
--- a/controller/util/util.go
+++ b/controller/util/util.go
@@ -28,6 +28,7 @@ func (n Tags) Swap(i, j int) {
 	n[i].Key, n[j].Key, n[i].Value, n[j].Value = n[j].Key, n[i].Key, n[j].Value, n[i].Value
 }
 
+// Hash returns a hash representing security group names
 func (a AWSStringSlice) Hash() *string {
 	sort.Sort(a)
 	hasher := md5.New()
@@ -85,6 +86,14 @@ func (subnets Subnets) AsAvailabilityZones() AvailabilityZones {
 	var out []*elbv2.AvailabilityZone
 	for _, s := range subnets {
 		out = append(out, &elbv2.AvailabilityZone{SubnetId: s, ZoneName: aws.String("")})
+	}
+	return out
+}
+
+func (s Subnets) String() string {
+	var out string
+	for _, sub := range s {
+		out += *sub
 	}
 	return out
 }


### PR DESCRIPTION
- Cache validation attempts in order to prevent constant calls on the
AWS API.
- Solves #44 

@bigkraig Note in this fix I needed to check for both a nil key and whether it had expired. In my testing, I found expired keys never became nil, just 'expired'.

Let me know if you've experienced differently, otherwise we need to make a helper function to check for cache invalidation since this means our current nil checks aren't enough.