### PR TITLE
Support tags

### DIFF
--- a/controller/alb/loadbalancer.go
+++ b/controller/alb/loadbalancer.go
@@ -84,12 +84,12 @@ func (lb *LoadBalancer) SyncState() *LoadBalancer {
 		log.Infof("Start ELBV2 (ALB) deletion.", *lb.IngressID)
 		lb.delete()
 
-	// No CurrentState means the load balancer doesn't exist in AWS and should be created.
+		// No CurrentState means the load balancer doesn't exist in AWS and should be created.
 	case lb.CurrentLoadBalancer == nil:
 		log.Infof("Start ELBV2 (ALB) creation.", *lb.IngressID)
 		lb.create()
 
-	// Current and Desired exist and the need for modification should be evaluated.
+		// Current and Desired exist and the need for modification should be evaluated.
 	default:
 		needsModification, _ := lb.needsModification()
 		if needsModification == 0 {

--- a/controller/config/annotations.go
+++ b/controller/config/annotations.go
@@ -274,7 +274,7 @@ func parseSubnets(s string) (out util.Subnets, err error) {
 		for _, subnet := range subnets {
 			value, ok := util.EC2Tags(subnet.Tags).Get("Name")
 			if ok {
-				if item := cache.Get(value); item != nil {
+				if item := cacheLookup(value); item != nil {
 					nv := append(item.Value().([]string), *subnet.SubnetId)
 					cache.Set(value, nv, time.Minute*60)
 				} else {
@@ -330,7 +330,7 @@ func parseSecurityGroups(s string) (out util.AWSStringSlice, err error) {
 		for _, sg := range sgs {
 			value, ok := util.EC2Tags(sg.Tags).Get("Name")
 			if ok {
-				if item := cache.Get(value); item != nil {
+				if item := cacheLookup(value); item != nil {
 					nv := append(item.Value().([]string), *sg.GroupId)
 					cache.Set(value, nv, time.Minute*60)
 				} else {


### PR DESCRIPTION
This stabilizes the tag logic and also introduces the ability to resolve resources sharing the same name tag.

e.g.
`sg-b80646d1` with `Name: k8s`
`sg-c20646d6` with `Name: k8s`

Will resolve just fine.

Resolves #21.