### PR TITLE
Prevent random deletions when non-type a record exists.

### DIFF
--- a/awsutil/route53.go
+++ b/awsutil/route53.go
@@ -167,7 +167,7 @@ func (r *Route53) Delete(in route53.ChangeResourceRecordSetsInput) error {
 func (r *Route53) DescribeResourceRecordSets(zoneID *string, hostname *string) (*route53.ResourceRecordSet, error) {
 	params := &route53.ListResourceRecordSetsInput{
 		HostedZoneId:    zoneID,
-		MaxItems:        aws.String("100"),
+		MaxItems:        aws.String("1"),
 		StartRecordName: hostname,
 		StartRecordType: aws.String(route53.RRTypeA),
 	}
@@ -187,8 +187,9 @@ func (r *Route53) DescribeResourceRecordSets(zoneID *string, hostname *string) (
 			continue
 		}
 
-		// TODO: It might be better to check if there are both CNAME and A records, rather than picking the first one
-		return record, nil
+		if strings.HasPrefix(*record.Name, *hostname) {
+			return record, nil
+		}
 	}
 
 	return nil, fmt.Errorf("ListResourceRecordSets(%s, %s) did not return any valid records", *zoneID, *hostname)

--- a/controller/alb/resourcerecordset.go
+++ b/controller/alb/resourcerecordset.go
@@ -56,13 +56,13 @@ func (r *ResourceRecordSet) SyncState(lb *LoadBalancer) *ResourceRecordSet {
 		log.Infof("Start Route53 resource record set deletion.", *r.IngressID)
 		r.delete(lb)
 
-	// No CurrentState means record doesn't exist in AWS and should be created.
+		// No CurrentState means record doesn't exist in AWS and should be created.
 	case r.CurrentResourceRecordSet == nil:
 		log.Infof("Start Route53 resource record set creation.", *r.IngressID)
 		r.PopulateFromLoadBalancer(lb.CurrentLoadBalancer)
 		r.create(lb)
 
-	// Current and Desired exist and need for modification should be evaluated.
+		// Current and Desired exist and need for modification should be evaluated.
 	default:
 		r.PopulateFromLoadBalancer(lb.CurrentLoadBalancer)
 		// Only perform modifictation if needed.
@@ -123,8 +123,8 @@ func (r *ResourceRecordSet) delete(lb *LoadBalancer) error {
 		return err
 	}
 
-	log.Infof("Completed deletion of Route 53 resource record set. DNS: %s | Type: %s | Target: %s.",
-		*lb.IngressID, *lb.Hostname, *r.CurrentResourceRecordSet.Type, log.Prettify(*r.CurrentResourceRecordSet.AliasTarget))
+	log.Infof("Completed deletion of Route 53 resource record set. DNS: %s | Type: %s.",
+		*lb.IngressID, *lb.Hostname, *r.CurrentResourceRecordSet.Type)
 	r.CurrentResourceRecordSet = nil
 	return nil
 }
@@ -190,17 +190,17 @@ func (r *ResourceRecordSet) needsModification() bool {
 	// No resource record set currently exists; modification required.
 	case r.CurrentResourceRecordSet == nil:
 		return true
-	// not sure if we need both conditions here.
-	// Hostname has changed; modification required.
+		// not sure if we need both conditions here.
+		// Hostname has changed; modification required.
 	case *r.CurrentResourceRecordSet.Name != *r.DesiredResourceRecordSet.Name:
 		return true
-	// Load balancer's hostname has changed; modification required.
+		// Load balancer's hostname has changed; modification required.
 	case *r.CurrentResourceRecordSet.AliasTarget.DNSName != *r.DesiredResourceRecordSet.AliasTarget.DNSName:
 		return true
-	// DNS record's resource type has changed; modification required.
+		// DNS record's resource type has changed; modification required.
 	case *r.CurrentResourceRecordSet.Type != *r.DesiredResourceRecordSet.Type:
 		return true
-	// Load balancer's dns hosted zone has changed; modification required.
+		// Load balancer's dns hosted zone has changed; modification required.
 	case *r.CurrentResourceRecordSet.AliasTarget.HostedZoneId != *r.DesiredResourceRecordSet.AliasTarget.HostedZoneId:
 		return true
 	}

--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -2,9 +2,8 @@ package controller
 
 import (
 	"fmt"
-	"sync"
-
 	"sort"
+	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
@@ -226,7 +225,8 @@ func assembleIngresses(ac *ALBController) ALBIngressesT {
 		}
 
 		log.Infof("Fetching resource recordset for %s/%s %s", "controller", namespace, ingressName, hostname)
-		resourceRecordSet, err := awsutil.Route53svc.DescribeResourceRecordSets(zone.Id, &hostname)
+		resourceRecordSet, err := awsutil.Route53svc.DescribeResourceRecordSets(zone.Id,
+			&hostname)
 		if err != nil {
 			log.Errorf("Failed to find %s in AWS Route53", "controller", hostname)
 		}
@@ -234,8 +234,8 @@ func assembleIngresses(ac *ALBController) ALBIngressesT {
 		ingressID := namespace + "-" + ingressName
 
 		rs := &alb.ResourceRecordSet{
-			IngressID: &ingressID,
-			ZoneID:    zone.Id,
+			IngressID:                &ingressID,
+			ZoneID:                   zone.Id,
 			CurrentResourceRecordSet: resourceRecordSet,
 		}
 


### PR DESCRIPTION
- ListResourceRecord sets will return another record when the start
record isn't present, based on current logic this will cause non type-a
record to be deleted, which can cause cascading delete over time of
many records.

- This fix ensures when looking up resource reocord sets, only the rrs
with the exact hostname requested is returned.

/cc @bigkraig 

Resolves #65