### PR TITLE
Rework SyncState in order to prevent crashes and be more clear

### DIFF
--- a/controller/alb/listener.go
+++ b/controller/alb/listener.go
@@ -53,10 +53,10 @@ func NewListener(annotations *config.Annotations, ingressID *string) []*Listener
 	return listeners
 }
 
-// SyncState compares the current and desired state of this Listener instance. Comparison
+// Reconcile compares the current and desired state of this Listener instance. Comparison
 // results in no action, the creation, the deletion, or the modification of an AWS listener to
 // satisfy the ingress's current state.
-func (l *Listener) SyncState(lb *LoadBalancer) error {
+func (l *Listener) Reconcile(lb *LoadBalancer) error {
 	switch {
 
 	case l.DesiredListener == nil: // listener should be deleted

--- a/controller/alb/listeners.go
+++ b/controller/alb/listeners.go
@@ -35,7 +35,7 @@ func (ls Listeners) Reconcile(lb *LoadBalancer, tgs *TargetGroups) error {
 		if listener.deleted {
 			// TODO: without this check, you'll get an index out of range exception
 			// during a full ALB deletion. Shouldn't have to do this check... This its
-			// related to .
+			// related to https://github.com/coreos/alb-ingress-controller/issues/25.
 			if i > len(newListenerList)-1 {
 				return nil
 			}

--- a/controller/alb/listeners.go
+++ b/controller/alb/listeners.go
@@ -17,24 +17,35 @@ func (ls Listeners) Find(listener *elbv2.Listener) int {
 	return -1
 }
 
-// SyncState kicks of the state synchronization for every Listener in this Listeners instances.
-func (ls Listeners) SyncState(lb *LoadBalancer, tgs *TargetGroups) Listeners {
-	// TODO: We currently only support 1 listener. Possibly only 1 TG?  We need logic that can associate specific
-	// TargetGroups with specific listeners.
-	var listeners Listeners
+// SyncState kicks off the state synchronization for every Listener in this Listeners instances.
+func (ls Listeners) SyncState(lb *LoadBalancer, tgs *TargetGroups) error {
 	if len(ls) < 1 {
-		return listeners
+		return nil
 	}
 
-	for _, listener := range ls {
-		l := listener.SyncState(lb)
-		l.Rules = l.Rules.SyncState(lb, l)
-		if l != nil && !l.deleted {
-			listeners = append(listeners, l)
+	newListenerList := ls
+
+	for i, listener := range ls {
+		if err := listener.SyncState(lb); err != nil {
+			return err
+		}
+		if err := listener.Rules.SyncState(lb, listener); err != nil {
+			return err
+		}
+		if listener.deleted {
+			// TODO: without this check, you'll get an index out of range exception
+			// during a full ALB deletion. Shouldn't have to do this check... This its
+			// related to .
+			if i > len(newListenerList)-1 {
+				return nil
+			}
+
+			newListenerList = append(newListenerList[:i], newListenerList[i+1:]...)
 		}
 	}
 
-	return listeners
+	lb.Listeners = newListenerList
+	return nil
 }
 
 // StripDesiredState removes the DesiredListener from all Listeners in the slice.

--- a/controller/alb/listeners.go
+++ b/controller/alb/listeners.go
@@ -17,8 +17,8 @@ func (ls Listeners) Find(listener *elbv2.Listener) int {
 	return -1
 }
 
-// SyncState kicks off the state synchronization for every Listener in this Listeners instances.
-func (ls Listeners) SyncState(lb *LoadBalancer, tgs *TargetGroups) error {
+// Reconcile kicks off the state synchronization for every Listener in this Listeners instances.
+func (ls Listeners) Reconcile(lb *LoadBalancer, tgs *TargetGroups) error {
 	if len(ls) < 1 {
 		return nil
 	}
@@ -26,10 +26,10 @@ func (ls Listeners) SyncState(lb *LoadBalancer, tgs *TargetGroups) error {
 	newListenerList := ls
 
 	for i, listener := range ls {
-		if err := listener.SyncState(lb); err != nil {
+		if err := listener.Reconcile(lb); err != nil {
 			return err
 		}
-		if err := listener.Rules.SyncState(lb, listener); err != nil {
+		if err := listener.Rules.Reconcile(lb, listener); err != nil {
 			return err
 		}
 		if listener.deleted {

--- a/controller/alb/loadbalancer.go
+++ b/controller/alb/loadbalancer.go
@@ -74,10 +74,10 @@ func NewLoadBalancer(clustername, namespace, ingressname, hostname string, ingre
 	return lb
 }
 
-// SyncState compares the current and desired state of this LoadBalancer instance. Comparison
+// Reconcile compares the current and desired state of this LoadBalancer instance. Comparison
 // results in no action, the creation, the deletion, or the modification of an AWS ELBV2 (ALB) to
 // satisfy the ingress's current state.
-func (lb *LoadBalancer) SyncState() error {
+func (lb *LoadBalancer) Reconcile() error {
 	switch {
 	case lb.DesiredLoadBalancer == nil: // lb should be deleted
 		if lb.CurrentLoadBalancer == nil {

--- a/controller/alb/loadbalancer.go
+++ b/controller/alb/loadbalancer.go
@@ -77,34 +77,47 @@ func NewLoadBalancer(clustername, namespace, ingressname, hostname string, ingre
 // SyncState compares the current and desired state of this LoadBalancer instance. Comparison
 // results in no action, the creation, the deletion, or the modification of an AWS ELBV2 (ALB) to
 // satisfy the ingress's current state.
-func (lb *LoadBalancer) SyncState() *LoadBalancer {
+func (lb *LoadBalancer) SyncState() error {
 	switch {
-	// No DesiredState means the load balancer should be deleted.
-	case lb.DesiredLoadBalancer == nil:
+	case lb.DesiredLoadBalancer == nil: // lb should be deleted
+		if lb.CurrentLoadBalancer == nil {
+			break
+		}
 		log.Infof("Start ELBV2 (ALB) deletion.", *lb.IngressID)
-		lb.delete()
+		if err := lb.delete(); err != nil {
+			return err
+		}
+		log.Infof("Completed ELBV2 (ALB) deletion. Name: %s | ARN: %s",
+			*lb.IngressID, *lb.CurrentLoadBalancer.LoadBalancerName,
+			*lb.CurrentLoadBalancer.LoadBalancerArn)
 
-		// No CurrentState means the load balancer doesn't exist in AWS and should be created.
-	case lb.CurrentLoadBalancer == nil:
+	case lb.CurrentLoadBalancer == nil: // lb doesn't exist and should be created
 		log.Infof("Start ELBV2 (ALB) creation.", *lb.IngressID)
-		lb.create()
+		if err := lb.create(); err != nil {
+			return err
+		}
+		log.Infof("Completed ELBV2 (ALB) creation. Name: %s | ARN: %s",
+			*lb.IngressID, *lb.CurrentLoadBalancer.LoadBalancerName,
+			*lb.CurrentLoadBalancer.LoadBalancerArn)
 
-		// Current and Desired exist and the need for modification should be evaluated.
-	default:
+	default: // check for diff between lb current and desired, modify if necessary
 		needsModification, _ := lb.needsModification()
 		if needsModification == 0 {
 			log.Debugf("No modification of ELBV2 (ALB) required.", *lb.IngressID)
-			return lb
+			return nil
 		}
 
 		log.Infof("Start ELBV2 (ALB) modification.", *lb.IngressID)
-		lb.modify()
+		if err := lb.modify(); err != nil {
+			return err
+		}
 	}
 
-	return lb
+	return nil
 }
 
 // create requests a new ELBV2 (ALB) is created in AWS.
+
 func (lb *LoadBalancer) create() error {
 	in := elbv2.CreateLoadBalancerInput{
 		Name:           lb.DesiredLoadBalancer.LoadBalancerName,
@@ -121,8 +134,6 @@ func (lb *LoadBalancer) create() error {
 	}
 
 	lb.CurrentLoadBalancer = o
-	log.Infof("Completed ELBV2 (ALB) creation. Name: %s | ARN: %s",
-		*lb.IngressID, *lb.CurrentLoadBalancer.LoadBalancerName, *lb.CurrentLoadBalancer.LoadBalancerArn)
 	return nil
 }
 
@@ -200,9 +211,7 @@ func (lb *LoadBalancer) delete() error {
 		return err
 	}
 
-	log.Infof("Completed ELBV2 (ALB) deletion. Name: %s | ARN: %s",
-		*lb.IngressID, *lb.CurrentLoadBalancer.LoadBalancerName,
-		*lb.CurrentLoadBalancer.LoadBalancerArn)
+	lb.Deleted = true
 	return nil
 }
 

--- a/controller/alb/loadbalancers.go
+++ b/controller/alb/loadbalancers.go
@@ -13,24 +13,24 @@ func (l LoadBalancers) Find(lb *LoadBalancer) int {
 	return -1
 }
 
-// SyncState calls for state synchronization (comparison of current and desired) for the load
+// Reconcile calls for state synchronization (comparison of current and desired) for the load
 // balancer and its resource record set, target group(s), and listener(s).
-func (l LoadBalancers) SyncState() (LoadBalancers, error) {
+func (l LoadBalancers) Reconcile() (LoadBalancers, error) {
 	loadbalancers := l
 
 	for i, loadbalancer := range l {
 
-		if err := loadbalancer.SyncState(); err != nil {
+		if err := loadbalancer.Reconcile(); err != nil {
 			return loadbalancers, err
 		}
-		if err := loadbalancer.ResourceRecordSet.SyncState(loadbalancer); err != nil {
+		if err := loadbalancer.ResourceRecordSet.Reconcile(loadbalancer); err != nil {
 			return loadbalancers, err
 		}
-		if err := loadbalancer.TargetGroups.SyncState(loadbalancer); err != nil {
+		if err := loadbalancer.TargetGroups.Reconcile(loadbalancer); err != nil {
 			return loadbalancers, err
 		}
 		// This syncs listeners and rules
-		if err := loadbalancer.Listeners.SyncState(loadbalancer, &loadbalancer.TargetGroups); err != nil {
+		if err := loadbalancer.Listeners.Reconcile(loadbalancer, &loadbalancer.TargetGroups); err != nil {
 			return loadbalancers, err
 		}
 		// If the lb was deleted, remove it from the list to be returned.

--- a/controller/alb/resourcerecordset.go
+++ b/controller/alb/resourcerecordset.go
@@ -46,10 +46,10 @@ func NewResourceRecordSet(hostname *string, ingressID *string) (*ResourceRecordS
 	return record, nil
 }
 
-// SyncState compares the current and desired state of this ResourceRecordSet instance. Comparison
+// Reconcile compares the current and desired state of this ResourceRecordSet instance. Comparison
 // results in no action, the creation, the deletion, or the modification of Route 53 resource
 // record set to satisfy the ingress's current state.
-func (r *ResourceRecordSet) SyncState(lb *LoadBalancer) error {
+func (r *ResourceRecordSet) Reconcile(lb *LoadBalancer) error {
 	switch {
 	case r.DesiredResourceRecordSet == nil: // rrs should be deleted
 		if r.CurrentResourceRecordSet == nil {

--- a/controller/alb/rule.go
+++ b/controller/alb/rule.go
@@ -49,10 +49,10 @@ func NewRule(path extensions.HTTPIngressPath, ingressID *string) *Rule {
 	return rule
 }
 
-// SyncState compares the current and desired state of this Rule instance. Comparison
+// Reconcile compares the current and desired state of this Rule instance. Comparison
 // results in no action, the creation, the deletion, or the modification of an AWS Rule to
 // satisfy the ingress's current state.
-func (r *Rule) SyncState(lb *LoadBalancer, l *Listener) error {
+func (r *Rule) Reconcile(lb *LoadBalancer, l *Listener) error {
 	switch {
 	case r.DesiredRule == nil: // rule should be deleted
 		if r.CurrentRule == nil {

--- a/controller/alb/rules.go
+++ b/controller/alb/rules.go
@@ -7,11 +7,11 @@ import (
 // Rules contains a slice of Rules
 type Rules []*Rule
 
-// SyncState kicks off the state synchronization for every Rule in this Rules slice.
-func (r Rules) SyncState(lb *LoadBalancer, l *Listener) error {
+// Reconcile kicks off the state synchronization for every Rule in this Rules slice.
+func (r Rules) Reconcile(lb *LoadBalancer, l *Listener) error {
 
 	for i, rule := range r {
-		if err := rule.SyncState(lb, l); err != nil {
+		if err := rule.Reconcile(lb, l); err != nil {
 			return err
 		}
 		if rule.deleted {

--- a/controller/alb/rules.go
+++ b/controller/alb/rules.go
@@ -8,17 +8,18 @@ import (
 type Rules []*Rule
 
 // SyncState kicks off the state synchronization for every Rule in this Rules slice.
-func (r Rules) SyncState(lb *LoadBalancer, l *Listener) Rules {
-	var ruleList Rules
+func (r Rules) SyncState(lb *LoadBalancer, l *Listener) error {
 
-	for _, rule := range r {
-		syncedRule := rule.SyncState(lb, l)
-		if syncedRule != nil {
-			ruleList = append(ruleList, syncedRule)
+	for i, rule := range r {
+		if err := rule.SyncState(lb, l); err != nil {
+			return err
+		}
+		if rule.deleted {
+			l.Rules = append(l.Rules[:i], l.Rules[i+1:]...)
 		}
 	}
 
-	return ruleList
+	return nil
 }
 
 // Find returns the position in the Rules slice of the rule parameter

--- a/controller/alb/targetgroup.go
+++ b/controller/alb/targetgroup.go
@@ -79,10 +79,10 @@ func NewTargetGroup(annotations *config.Annotations, tags util.Tags, clustername
 	return targetGroup
 }
 
-// SyncState compares the current and desired state of this TargetGroup instance. Comparison
+// Reconcile compares the current and desired state of this TargetGroup instance. Comparison
 // results in no action, the creation, the deletion, or the modification of an AWS target group to
 // satisfy the ingress's current state.
-func (tg *TargetGroup) SyncState(lb *LoadBalancer) error {
+func (tg *TargetGroup) Reconcile(lb *LoadBalancer) error {
 	switch {
 	// No DesiredState means target group should be deleted.
 	case tg.DesiredTargetGroup == nil:

--- a/controller/alb/targetgroup.go
+++ b/controller/alb/targetgroup.go
@@ -24,6 +24,7 @@ type TargetGroup struct {
 	DesiredTargets     util.AWSStringSlice
 	CurrentTargetGroup *elbv2.TargetGroup
 	DesiredTargetGroup *elbv2.TargetGroup
+	deleted            bool
 }
 
 // NewTargetGroup returns a new alb.TargetGroup based on the parameters provided.
@@ -81,28 +82,44 @@ func NewTargetGroup(annotations *config.Annotations, tags util.Tags, clustername
 // SyncState compares the current and desired state of this TargetGroup instance. Comparison
 // results in no action, the creation, the deletion, or the modification of an AWS target group to
 // satisfy the ingress's current state.
-func (tg *TargetGroup) SyncState(lb *LoadBalancer) *TargetGroup {
+func (tg *TargetGroup) SyncState(lb *LoadBalancer) error {
 	switch {
 	// No DesiredState means target group should be deleted.
 	case tg.DesiredTargetGroup == nil:
+		if tg.CurrentTargetGroup == nil {
+			break
+		}
 		log.Infof("Start TargetGroup deletion.", *tg.IngressID)
-		tg.delete()
+		if err := tg.delete(); err != nil {
+			return err
+		}
+		log.Infof("Completed TargetGroup deletion.", *tg.IngressID)
 
-	// No CurrentState means target group doesn't exist in AWS and should be created.
+		// No CurrentState means target group doesn't exist in AWS and should be created.
 	case tg.CurrentTargetGroup == nil:
 		log.Infof("Start TargetGroup creation.", *tg.IngressID)
-		tg.create(lb)
+		if err := tg.create(lb); err != nil {
+			return err
+		}
+		log.Infof("Succeeded TargetGroup creation. ARN: %s | Name: %s.",
+			*tg.IngressID, *tg.CurrentTargetGroup.TargetGroupArn,
+			*tg.CurrentTargetGroup.TargetGroupName)
 
-	// Current and Desired exist and need for modification should be evaluated.
+		// Current and Desired exist and need for modification should be evaluated.
 	case tg.needsModification():
 		log.Infof("Start TargetGroup modification.", *tg.IngressID)
-		tg.modify(lb)
+		if err := tg.modify(lb); err != nil {
+			return err
+		}
+		log.Infof("Succeeded TargetGroup modification. ARN: %s | Name: %s.",
+			*tg.IngressID, *tg.CurrentTargetGroup.TargetGroupArn,
+			*tg.CurrentTargetGroup.TargetGroupName)
 
 	default:
 		log.Debugf("No TargetGroup modification required.", *tg.IngressID)
 	}
 
-	return tg
+	return nil
 }
 
 // Creates a new TargetGroup in AWS.
@@ -147,8 +164,6 @@ func (tg *TargetGroup) create(lb *LoadBalancer) error {
 		return err
 	}
 
-	log.Infof("Succeeded TargetGroup creation. ARN: %s | Name: %s.",
-		*tg.IngressID, *tg.CurrentTargetGroup.TargetGroupArn, *tg.CurrentTargetGroup.TargetGroupName)
 	return nil
 }
 
@@ -193,8 +208,6 @@ func (tg *TargetGroup) modify(lb *LoadBalancer) error {
 		tg.registerTargets()
 	}
 
-	log.Infof("Succeeded TargetGroup modification. ARN: %s | Name: %s.",
-		*tg.IngressID, *tg.CurrentTargetGroup.TargetGroupArn, *tg.CurrentTargetGroup.TargetGroupName)
 	return nil
 }
 
@@ -205,7 +218,8 @@ func (tg *TargetGroup) delete() error {
 		log.Errorf("Failed TargetGroup deletion. ARN: %s.", *tg.IngressID, *tg.CurrentTargetGroup.TargetGroupArn)
 		return err
 	}
-	log.Infof("Completed TargetGroup deletion. ARN: %s.", *tg.IngressID, *tg.CurrentTargetGroup.TargetGroupArn)
+
+	tg.deleted = true
 	return nil
 }
 

--- a/controller/alb/targetgroups.go
+++ b/controller/alb/targetgroups.go
@@ -30,15 +30,17 @@ func (t TargetGroups) Find(tg *TargetGroup) int {
 
 // SyncState kicks off the state synchronization for every target group inside this TargetGroups
 // instance.
-func (t TargetGroups) SyncState(lb *LoadBalancer) TargetGroups {
-	var targetgroups TargetGroups
-	for _, targetgroup := range t {
-		tg := targetgroup.SyncState(lb)
-		if tg != nil {
-			targetgroups = append(targetgroups, tg)
+func (t TargetGroups) SyncState(lb *LoadBalancer) error {
+	for i, targetgroup := range t {
+		if err := targetgroup.SyncState(lb); err != nil {
+			return err
+		}
+		if targetgroup.deleted {
+			lb.TargetGroups = append(lb.TargetGroups[:i], lb.TargetGroups[i+1:]...)
 		}
 	}
-	return targetgroups
+
+	return nil
 }
 
 // StripDesiredState removes the DesiredTags, DesiredTargetGroup, and DesiredTargets from all TargetGroups

--- a/controller/alb/targetgroups.go
+++ b/controller/alb/targetgroups.go
@@ -28,11 +28,11 @@ func (t TargetGroups) Find(tg *TargetGroup) int {
 	return -1
 }
 
-// SyncState kicks off the state synchronization for every target group inside this TargetGroups
+// Reconcile kicks off the state synchronization for every target group inside this TargetGroups
 // instance.
-func (t TargetGroups) SyncState(lb *LoadBalancer) error {
+func (t TargetGroups) Reconcile(lb *LoadBalancer) error {
 	for i, targetgroup := range t {
-		if err := targetgroup.SyncState(lb); err != nil {
+		if err := targetgroup.Reconcile(lb); err != nil {
 			return err
 		}
 		if targetgroup.deleted {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -72,7 +72,7 @@ func (ac *ALBController) OnUpdate(ingressConfiguration ingress.Configuration) ([
 
 	// Capture any ingresses missing from the new list that qualify for deletion.
 	deletable := ac.ingressToDelete(ALBIngresses)
-	// If deletable ingresses were found, add them to the list so they'll be deleted when SyncState()
+	// If deletable ingresses were found, add them to the list so they'll be deleted when Reconcile()
 	// is called.
 	if len(deletable) > 0 {
 		ALBIngresses = append(ALBIngresses, deletable...)
@@ -104,7 +104,7 @@ func (ac *ALBController) Reload(data []byte) ([]byte, bool, error) {
 	// Sync the state, resulting in creation, modify, delete, or no action, for every ALBIngress
 	// instance known to the ALBIngress controller.
 	for _, ALBIngress := range ac.ALBIngresses {
-		ALBIngress.SyncState()
+		ALBIngress.Reconcile()
 	}
 
 	return []byte(""), true, nil

--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -336,13 +336,13 @@ func assembleIngresses(ac *ALBController) ALBIngressesT {
 	return ALBIngresses
 }
 
-// SyncState begins the state sync for all AWS resource satisfying this ALBIngress instance.
-func (a *ALBIngress) SyncState() {
+// Reconcile begins the state sync for all AWS resource satisfying this ALBIngress instance.
+func (a *ALBIngress) Reconcile() {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	var err error
 
-	a.LoadBalancers, err = a.LoadBalancers.SyncState()
+	a.LoadBalancers, err = a.LoadBalancers.Reconcile()
 	if err != nil {
 		log.Errorf("Sync stopped due to error. Error: %s", *a.id, err.Error())
 	}

--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -340,8 +340,12 @@ func assembleIngresses(ac *ALBController) ALBIngressesT {
 func (a *ALBIngress) SyncState() {
 	a.lock.Lock()
 	defer a.lock.Unlock()
+	var err error
 
-	a.LoadBalancers = a.LoadBalancers.SyncState()
+	a.LoadBalancers, err = a.LoadBalancers.SyncState()
+	if err != nil {
+		log.Errorf("Sync stopped due to error. Error: %s", *a.id, err.Error())
+	}
 }
 
 // Name returns the name of the ingress


### PR DESCRIPTION
This PR attempts to rework SyncState (now called Reconcile) in order to prevent crashes and overall be more readable and clean. When a sync step fails, it now bubbles up and stops the syncing process from continuing, preventing other syncs from crashing due to assumptions that previous syncs succeeded.

It also ensures that deletions only attempt to delete what was previously created.

We still will have to answer many question such as "how should we modify x in y situation", but overall this should bring more stability.

For example, when reproducing the target group issue from #68,

Previously this situation caused a crash, now it would produce the following:

```
[ALB-INGRESS] [echoserver-echoserver3] [INFO]: Failed TargetGroup creation. Error: DuplicateTargetGroupName: A target group with the same name 'dev1-32217-HTTP-2a38643' exists, but with different settings                                                                                                                                                                                  
  status code: 400, request id: a32894e5-2659-11e7-b8af-1733e08cc543.                                                                                                                          
[ALB-INGRESS] [echoserver-echoserver3] [ERROR]: Sync stopped due to error. Error: DuplicateTargetGroupName: A target group with the same name 'dev1-32217-HTTP-2a38643' exists, but with different settings                                                                                                                                                                                   
  status code: 400, request id: a32894e5-2659-11e7-b8af-1733e08cc543                                                                                                                           
I0421 06:13:28.977832       1 controller.go:439] ingress backend successfully reloaded...
```

From here the controller can continue to reconcile (and not crash) along with work on other ingress resources. Deletion of this resource will also succeed, even though it only achieved partial creations.

Let me know your thoughts @bigkraig.