### PR TITLE
fix AWS env variable name in the helm chart

### DIFF
--- a/helm/alb-ingress-controller/README.md
+++ b/helm/alb-ingress-controller/README.md
@@ -45,7 +45,7 @@ The following tables lists the configurable parameters of the alb-ingress-contro
 Parameter | Description | Default
 --- | --- | ---
 `aws.accessKeyId` | If provided, AWS_ACCESS_KEY_ID environment variable will be set to this value | `""`
-`aws.accessSecretKey` | If provided, AWS_ACCESS_SECRET_KEY environment variable will be set to this value | `""`
+`aws.secretAccessKey` | If provided, AWS_SECRET_ACCESS_KEY environment variable will be set to this value | `""`
 `aws.debug` | If true, enables logging on all outbound AWS API requests | `false`
 `aws.region` | (REQUIRED) AWS region in which this ingress controller will operate | `us-west-1`
 `clusterName` | (REQUIRED) Resources created by the ALB Ingress controller will be prefixed with this string | `k8s`

--- a/helm/alb-ingress-controller/templates/controller-deployment.yaml
+++ b/helm/alb-ingress-controller/templates/controller-deployment.yaml
@@ -38,9 +38,9 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               value: "{{ .Values.aws.accessKeyId }}"
           {{- end }}
-          {{- if .Values.aws.accessSecretKey }}
-            - name: AWS_ACCESS_SECRET_KEY
-              value: "{{ .Values.aws.accessSecretKey }}"
+          {{- if .Values.aws.secretAccessKey }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: "{{ .Values.aws.secretAccessKey }}"
           {{- end }}
             - name: AWS_DEBUG
               value: "{{ .Values.aws.debug }}"

--- a/helm/alb-ingress-controller/values.yaml
+++ b/helm/alb-ingress-controller/values.yaml
@@ -5,9 +5,9 @@ aws:
   #
   accessKeyId: ""
 
-  ## If provided, AWS_ACCESS_SECRET_KEY environment variable will be set to this value
+  ## If provided, AWS_SECRET_ACCESS_KEY environment variable will be set to this value
   #
-  accessSecretKey: ""
+  secretAccessKey: ""
 
   ## If true, enables logging on all outbound AWS API requests
   #


### PR DESCRIPTION
In the helm chart the env variable for the  secret access key is set as `AWS_ACCESS_SECRET_KEY` but should be  `AWS_SECRET_ACCESS_KEY`.
