### PR TITLE
Fix for nil annotations

### DIFF
--- a/controller/config/annotations.go
+++ b/controller/config/annotations.go
@@ -59,6 +59,10 @@ type ListenerPort struct {
 // annotations are also cached, meaning there will be no reattempt to parse annotations until the
 // cache expires or the value(s) change.
 func ParseAnnotations(annotations map[string]string) (*Annotations, error) {
+	if annotations == nil {
+		return nil, fmt.Errorf(`Necessary annotations missing. Must include at least %s, %s`, subnetsKey, securityGroupsKey)
+	}
+
 	sortedAnnotations := util.SortedMap(annotations)
 	cacheKey := "annotations " + awsutil.Prettify(sortedAnnotations)
 

--- a/controller/config/annotations_test.go
+++ b/controller/config/annotations_test.go
@@ -1,9 +1,15 @@
 package config
 
-import (
-	"testing"
-	//"github.com/aws/aws-sdk-go/aws"
-)
+import "testing"
+
+//"github.com/aws/aws-sdk-go/aws"
+
+func TestParseAnnotations(t *testing.T) {
+	_, err := ParseAnnotations(nil)
+	if err == nil {
+		t.Fatalf("ParseAnnotations should not accept nil for annotations")
+	}
+}
 
 /*func TestParsePort(t *testing.T) {
 	var tests = []struct {


### PR DESCRIPTION
This is a small, quick fix for the ALB ingress to error gracefully when an ingress has no annotations, providing some feedback to help the user with adding the minimum required annotations.

Happy to fix higher up the chain if need be, perhaps ingress validation is required?