### PR TITLE
reconcile: don't stop due to single failures

### DIFF
--- a/controller/alb/loadbalancer.go
+++ b/controller/alb/loadbalancer.go
@@ -28,6 +28,7 @@ type LoadBalancer struct {
 	DesiredTags         util.Tags
 	Deleted             bool // flag representing the LoadBalancer instance was fully deleted.
 	LastRulePriority    int64
+	LastError           error // last error (if any) this load balancer experienced when attempting to reconcile
 }
 
 type loadBalancerChange uint

--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -345,11 +345,11 @@ func (a *ALBIngress) Reconcile() {
 	if a.tainted {
 		return
 	}
-	var err error
+	errLBs := alb.LoadBalancers{}
 
-	a.LoadBalancers, err = a.LoadBalancers.Reconcile()
-	if err != nil {
-		log.Errorf("Sync stopped due to error. Error: %s", *a.id, err.Error())
+	a.LoadBalancers, errLBs = a.LoadBalancers.Reconcile()
+	for _, errLB := range errLBs {
+		log.Errorf("Failed to reconcile state on this ingress resource. Error: %s", *errLB.IngressID, errLB.LastError)
 	}
 }
 


### PR DESCRIPTION
- This commit ensures that ingress resources that have failed during
reconcile are captured in their own array for logging. Additionally,
rather than bubbling the error up and brining a Reconcile event to a
complete halt, just that ingress will be stopped, logged, and the rest
are able to continue reconciling.