### PR TITLE
Add `ingresses/status` to fix the error:

### DIFF
--- a/examples/alb-ingress-controller-v1.6.0.yaml
+++ b/examples/alb-ingress-controller-v1.6.0.yaml
@@ -101,6 +101,7 @@ rules:
   resources:
   - endpoints
   - ingresses
+  - ingresses/status
   - events
   verbs:
   - create


### PR DESCRIPTION
> error updating ingress rule: User "system:serviceaccount:kube-system:alb-ingress-controller" cannot update ingresses.extensions/status in the namespace "default". (put ingresses.extensions gophernotes)