### PR TITLE
Stop reconcile for lb that failed in any step

### DIFF
--- a/controller/alb/loadbalancer.go
+++ b/controller/alb/loadbalancer.go
@@ -130,7 +130,7 @@ func (lb *LoadBalancer) create() error {
 
 	o, err := awsutil.ALBsvc.Create(in)
 	if err != nil {
-		log.Errorf("Failed to create ELBV2 (ALB). Error: %s", err.Error())
+		log.Errorf("Failed to create ELBV2 (ALB). Error: %s", *lb.IngressID, err.Error())
 		return err
 	}
 

--- a/controller/alb/loadbalancers.go
+++ b/controller/alb/loadbalancers.go
@@ -26,19 +26,23 @@ func (l LoadBalancers) Reconcile() (LoadBalancers, LoadBalancers) {
 		if err := loadbalancer.Reconcile(); err != nil {
 			loadbalancer.LastError = err
 			errLBs = append(errLBs, loadbalancer)
+			continue
 		}
 		if err := loadbalancer.ResourceRecordSet.Reconcile(loadbalancer); err != nil {
 			loadbalancer.LastError = err
 			errLBs = append(errLBs, loadbalancer)
+			continue
 		}
 		if err := loadbalancer.TargetGroups.Reconcile(loadbalancer); err != nil {
 			loadbalancer.LastError = err
 			errLBs = append(errLBs, loadbalancer)
+			continue
 		}
 		// This syncs listeners and rules
 		if err := loadbalancer.Listeners.Reconcile(loadbalancer, &loadbalancer.TargetGroups); err != nil {
 			loadbalancer.LastError = err
 			errLBs = append(errLBs, loadbalancer)
+			continue
 		}
 		// If the lb was deleted, remove it from the list to be returned.
 		if loadbalancer.Deleted {

--- a/controller/alb/resourcerecordset.go
+++ b/controller/alb/resourcerecordset.go
@@ -26,7 +26,7 @@ func NewResourceRecordSet(hostname *string, ingressID *string) *ResourceRecordSe
 	zoneID, err := awsutil.Route53svc.GetZoneID(hostname)
 	resolveable := true
 	if err != nil {
-		log.Errorf("Unabled to locate ZoneId for %s.", *ingressID, *hostname)
+		log.Errorf("Unable to locate ZoneId for %s.", *ingressID, *hostname)
 		resolveable = false
 	}
 

--- a/controller/ingress.go
+++ b/controller/ingress.go
@@ -164,6 +164,12 @@ func NewALBIngressFromIngress(ingress *extensions.Ingress, ac *ALBController) (*
 
 			// Create a new ResourceRecordSet for the hostname.
 			resourceRecordSet := alb.NewResourceRecordSet(lb.Hostname, lb.IngressID)
+
+			// If the provided host wasn't resolvable, don't bother going further
+			if !resourceRecordSet.Resolveable {
+				continue
+			}
+
 			// If the load balancer has a CurrentResourceRecordSet, set
 			// this value inside our new resourceRecordSet.
 			if lb.ResourceRecordSet != nil {


### PR DESCRIPTION
- When an ingress resources failes any reconcile step, it should not
attempt subsequent steps as they rely on one another. e.g. For a
targetgroup reconcile to complete, the loadbalancer reconcile must
finish properly.

- Ensures that when a route53 hosted zone cannot be resolved, we don't
add this to our ingress list.