### PR TITLE
fail lb if resourcerecordset never populated

### DIFF
--- a/controller/alb/loadbalancers.go
+++ b/controller/alb/loadbalancers.go
@@ -1,5 +1,7 @@
 package alb
 
+import "errors"
+
 // LoadBalancers is a slice of LoadBalancer pointers
 type LoadBalancers []*LoadBalancer
 
@@ -24,6 +26,12 @@ func (l LoadBalancers) Reconcile() (LoadBalancers, LoadBalancers) {
 	for i, loadbalancer := range l {
 
 		if err := loadbalancer.Reconcile(); err != nil {
+			loadbalancer.LastError = err
+			errLBs = append(errLBs, loadbalancer)
+			continue
+		}
+		if loadbalancer.ResourceRecordSet == nil {
+			err := errors.New("ResourceRecordSet was never set, ingress is not implementable")
 			loadbalancer.LastError = err
 			errLBs = append(errLBs, loadbalancer)
 			continue


### PR DESCRIPTION
This comes up most often when either the service is missing or NodePort is not set on the service, resulting in endpoints not found.