### PR TITLE
Make Route53 integration optional

### DIFF
--- a/controller/alb/loadbalancers.go
+++ b/controller/alb/loadbalancers.go
@@ -17,7 +17,7 @@ func (l LoadBalancers) Find(lb *LoadBalancer) int {
 // balancer and its resource record set, target group(s), and listener(s). It returns 2
 // LoadBalancers (slices), the first being the list of all known LoadBalancers and the subset
 // second being of LoadBalancers, from the first list, that failed to reconcile.
-func (l LoadBalancers) Reconcile() (LoadBalancers, LoadBalancers) {
+func (l LoadBalancers) Reconcile(disableRoute53 bool) (LoadBalancers, LoadBalancers) {
 	loadbalancers := l
 	errLBs := LoadBalancers{}
 
@@ -28,10 +28,12 @@ func (l LoadBalancers) Reconcile() (LoadBalancers, LoadBalancers) {
 			errLBs = append(errLBs, loadbalancer)
 			continue
 		}
-		if err := loadbalancer.ResourceRecordSet.Reconcile(loadbalancer); err != nil {
-			loadbalancer.LastError = err
-			errLBs = append(errLBs, loadbalancer)
-			continue
+		if !disableRoute53 {
+			if err := loadbalancer.ResourceRecordSet.Reconcile(loadbalancer); err != nil {
+				loadbalancer.LastError = err
+				errLBs = append(errLBs, loadbalancer)
+				continue
+			}
 		}
 		if err := loadbalancer.TargetGroups.Reconcile(loadbalancer); err != nil {
 			loadbalancer.LastError = err

--- a/controller/config/config.go
+++ b/controller/config/config.go
@@ -2,6 +2,7 @@ package config
 
 // Config contains the ALB Ingress Controller configuration
 type Config struct {
-	ClusterName string
-	AWSDebug    bool
+	ClusterName    string
+	AWSDebug       bool
+	DisableRoute53 bool
 }

--- a/main.go
+++ b/main.go
@@ -31,9 +31,12 @@ func main() {
 
 	awsDebug, _ := strconv.ParseBool(os.Getenv("AWS_DEBUG"))
 
+	disableRoute53, _ := strconv.ParseBool(os.Getenv("DISABLE_ROUTE53"))
+
 	conf := &config.Config{
-		ClusterName: clusterName,
-		AWSDebug:    awsDebug,
+		ClusterName:    clusterName,
+		AWSDebug:       awsDebug,
+		DisableRoute53: disableRoute53,
 	}
 
 	if len(clusterName) > 11 {


### PR DESCRIPTION
Fixes #9. This PR allows wholesale disabling of Route53 integration by passing the environment variable `DISABLE_ROUTE53=true` at controller start.

There are a lot of ways this could be solved that are cleaner, so if people aren't happy with this sledgehammer approach I'd love this to be the start of a discussion.