### PR TITLE
Update Helm chart push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ after_success:
   - docker tag $REPO:$COMMIT $REPO:$TAG
   - docker push $REPO
   - /tmp/helm lint --strict helm/alb-ingress-controller
-  - [ "$TRAVIS_BRANCH" = "master" ] && helm/push.sh
+  - if [ "$TRAVIS_BRANCH" = "master" ];then helm/push.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ sudo: required
 
 env:
   global:
-    - HELM_VERSION=v2.4.1
-    - HELM_REGISTRY_VERSION=v0.3.8
+    - HELM_VERSION=v2.5.0
 
 go:
   - 1.8
@@ -19,7 +18,6 @@ before_install:
   - curl -L https://kubernetes-helm.storage.googleapis.com/helm-$HELM_VERSION-linux-amd64.tar.gz | tar -xz -C /tmp
   - mv /tmp/linux-amd64/helm /tmp
   - /tmp/helm init -c
-  - curl -L https://github.com/app-registry/helm-plugin/releases/download/$HELM_REGISTRY_VERSION/registry-helm-plugin-$HELM_REGISTRY_VERSION-linux-x64.tar.gz | tar -xz -C $HOME/.helm/plugins
 
 notifications:
   on_success: never
@@ -38,8 +36,4 @@ after_success:
   - docker tag $REPO:$COMMIT $REPO:$TAG
   - docker push $REPO
   - /tmp/helm lint --strict helm/alb-ingress-controller
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
-      /tmp/helm registry login -u $QUAY_USERNAME -p $QUAY_PASSWORD quay.io
-      cd helm/alb-ingress-controller
-      helm registry push --namespace coreos quay.io
-    fi
+  - [ "$TRAVIS_BRANCH" = "master" ] && helm/push.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ after_success:
   - docker tag $REPO:$COMMIT $REPO:$TAG
   - docker push $REPO
   - /tmp/helm lint --strict helm/alb-ingress-controller
-  - if [ "$TRAVIS_BRANCH" = "master" ];then helm/push.sh; fi
+  - if [ "$TRAVIS_BRANCH" = "master" ]; then helm/push.sh; fi

--- a/helm/alb-ingress-controller/Chart.yaml
+++ b/helm/alb-ingress-controller/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 name: alb-ingress-controller-helm
 sources:
   - https://github.com/coreos/alb-ingress-controller
-version: 0.0.2
+version: 0.0.3

--- a/helm/alb-ingress-controller/values.yaml
+++ b/helm/alb-ingress-controller/values.yaml
@@ -1,3 +1,9 @@
+# Quay.io doesn't allow container image & application repositories in the same organization
+# to share a name. In this case, the image is quay.io/coreos/alb-ingress-controller,
+# and the Helm chart is quay.io/coreos/alb-ingress-controller-helm. This variable
+# overrides the chart name.
+nameOverride: alb-ingress-controller
+
 ## Ref: https://github.com/coreos/alb-ingress-controller/blob/master/docs/configuration.md#aws-api-access
 #
 aws:

--- a/helm/push.sh
+++ b/helm/push.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+/tmp/helm plugin install https://github.com/app-registry/appr-helm-plugin
+/tmp/helm registry login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} quay.io
+
+cd helm/alb-ingress-controller
+/tmp/helm registry push --namespace coreos quay.io
+


### PR DESCRIPTION
* Use latest version of Helm
* Use new Helm plugin installation process to get registry plugin
* Override chart name to get around quay.io naming limitation
* Bump chart version

As before, I can't guarantee Travis will push the chart correctly, but I'm happy to help get it working. Would love to replace our old TM chart with this one.