### PR TITLE
Enable RBAC in Helm chart

### DIFF
--- a/alb-ingress-controller-helm/Chart.yaml
+++ b/alb-ingress-controller-helm/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 name: alb-ingress-controller-helm
 sources:
   - https://github.com/coreos/alb-ingress-controller
-version: 0.0.3
+version: 0.0.4

--- a/alb-ingress-controller-helm/README.md
+++ b/alb-ingress-controller-helm/README.md
@@ -63,6 +63,8 @@ Parameter | Description | Default
 `defaultBackend.replicaCount` | desired number of default backend pods | `1`
 `defaultBackend.resources` | default backend pod resource requests & limits | `{}`
 `defaultBackend.service.annotations` | annotations to be added to default backend service | `{}`
+`rbac.create` | If true, create & use RBAC resources | `true`
+`rbac.serviceAccountName` | ServiceAccount ALB ingress controller will use (ignored if rbac.create=true) | `default`
 `scope.ingressClass` | If provided, the ALB ingress controller will only act on Ingress resources annotated with this class | `alb`
 `scope.singleNamespace` | If true, the ALB ingress controller will only act on Ingress resources in a single namespace | `false` (watch all namespaces)
 `scope.watchNamespace` | If scope.singleNamespace=true, the ALB ingress controller will only act on Ingress resources in this namespace | `""` (namespace of the ALB ingress controller)

--- a/alb-ingress-controller-helm/templates/_helpers.tpl
+++ b/alb-ingress-controller-helm/templates/_helpers.tpl
@@ -7,6 +7,15 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Create a default fully qualified name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified controller name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/alb-ingress-controller-helm/templates/clusterrole.yaml
+++ b/alb-ingress-controller-helm/templates/clusterrole.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - endpoints
+      - events
+      - ingresses
+      - ingresses/status
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - configmaps
+      - nodes
+      - pods
+      - secrets
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/alb-ingress-controller-helm/templates/clusterrolebinding.yaml
+++ b/alb-ingress-controller-helm/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -66,6 +66,6 @@ spec:
       nodeSelector:
 {{ toYaml .Values.controller.nodeSelector | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" .}}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       terminationGracePeriodSeconds: 60
 

--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -66,5 +66,6 @@ spec:
       nodeSelector:
 {{ toYaml .Values.controller.nodeSelector | indent 8 }}
     {{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" .}}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       terminationGracePeriodSeconds: 60
 

--- a/alb-ingress-controller-helm/templates/serviceaccount.yaml
+++ b/alb-ingress-controller-helm/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+{{- end }}

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -74,6 +74,14 @@ defaultBackend:
   service:
     annotations: {}
 
+rbac:
+  ## If true, create & use RBAC resources
+  ##
+  create: true
+
+  ## Ignored if rbac.create is true
+  serviceAccountName: default
+
 scope:
   ## If provided, the ALB ingress controller will only act on Ingress resources annotated with this class
   ## Ref: https://github.com/coreos/alb-ingress-controller/blob/master/docs/configuration.md#limiting-ingress-class


### PR DESCRIPTION
- If `rbac.create=true` (the default), the appropriate ServiceAccount, ClusterRole, and ClusterRoleBinding are created.
- If `rbac.create=false` and `rbac.serviceAccountName` is provided, the Deployment will use (but not create) that ServiceAccount. Assumption is that the user will manage RBAC, not Helm.