### PR TITLE
update ingress' statuses with alb dns names

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,10 @@ import (
 	"github.com/coreos/alb-ingress-controller/controller"
 	"github.com/coreos/alb-ingress-controller/controller/config"
 	"github.com/coreos/alb-ingress-controller/log"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ingresscontroller "k8s.io/ingress/core/pkg/ingress/controller"
 )
 
@@ -47,7 +51,37 @@ func main() {
 	http.Handle("/metrics", promhttp.Handler())
 	go http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
 
-	ac := controller.NewALBController(&aws.Config{MaxRetries: aws.Int(5)}, conf)
+	apiServerHost := os.Getenv("KUBERNETES_APISERVER_HOST")
+	var config *rest.Config
+	var err error
+	// Create kubeclient
+	if len(apiServerHost) == 0 {
+		if config, err = rest.InClusterConfig(); err != nil {
+			glog.Fatalf("error creating client configuration: %v", err)
+		}
+	} else {
+		kubeConfigFile := os.Getenv("KUBECONFIG_FILE")
+		if len(kubeConfigFile) == 0 {
+			glog.Fatalf("env 'KUBECONFIG_FILE' should be specified with 'KUBERNETES_APISERVER_HOST'")
+		}
+		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfigFile},
+			&clientcmd.ConfigOverrides{
+				ClusterInfo: clientcmdapi.Cluster{
+					Server: apiServerHost,
+				},
+			}).ClientConfig()
+		if err != nil {
+			glog.Fatalf("error creating client configuration: %v", err)
+		}
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		glog.Fatalf("Failed to create client: %v.", err)
+	}
+
+	ac := controller.NewALBController(&aws.Config{MaxRetries: aws.Int(5)}, conf, kubeClient)
 	ic := ingresscontroller.NewIngressController(ac)
 
 	ac.IngressClass = ic.IngressClass()


### PR DESCRIPTION
In combination with `DISABLE_ROUTE53`, this supports external updates of route53 by reflecting the ALBs' dns names in the `status.loadBalancer.ingress` field of the associated ingress object.

(i.e, `kubectl get ingress` will now show a correctly-populated value for the ADDRESS field)