### PR TITLE
Support Helm release name = chart name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /alb-ingress-controller
 /server
+*.tgz

--- a/alb-ingress-controller-helm/Chart.yaml
+++ b/alb-ingress-controller-helm/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 name: alb-ingress-controller-helm
 sources:
   - https://github.com/coreos/alb-ingress-controller
-version: 0.0.4
+version: 0.0.5

--- a/alb-ingress-controller-helm/README.md
+++ b/alb-ingress-controller-helm/README.md
@@ -55,6 +55,7 @@ Parameter | Description | Default
 `controller.nodeSelector` | node labels for controller pod assignment | `{}`
 `controller.podAnnotations` | annotations to be added to controller pod | `{}`
 `controller.resources` | controller pod resource requests & limits | `{}`
+`controller.service.annotations` | annotations to be added to controller service | `{}`
 `defaultBackend.image.repository` | default backend container image repository | `gcr.io/google_containers/defaultbackend`
 `defaultBackend.image.tag` | default backend container image tag | `1.2`
 `defaultBackend.image.pullPolicy` | default backend container image pull policy | `IfNotPresent`

--- a/alb-ingress-controller-helm/templates/_helpers.tpl
+++ b/alb-ingress-controller-helm/templates/_helpers.tpl
@@ -12,7 +12,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if ne $name .Release.Name -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -21,7 +25,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "controller.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if ne $name .Release.Name -}}
 {{- printf "%s-%s-controller" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -30,5 +38,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "defaultBackend.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if ne $name .Release.Name -}}
 {{- printf "%s-%s-default-backend" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-default-backend" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}

--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -58,6 +58,9 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+          ports:
+            - containerPort: 8080
+              protocol: TCP
         {{- if .Values.controller.resources }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}

--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -19,6 +19,9 @@ spec:
         app: {{ template "name" . }}
         component: controller
         release: {{ .Release.Name }}
+      {{- if .Values.controller.podLabels }}
+{{ toYaml .Values.controller.podLabels | indent 8}}
+      {{- end }}
     spec:
       containers:
         - name: {{ template "name" . }}-controller

--- a/alb-ingress-controller-helm/templates/controller-service.yaml
+++ b/alb-ingress-controller-helm/templates/controller-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.controller.service.annotations }}
+  annotations:
+{{ toYaml .Values.controller.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "controller.fullname" . }}
+spec:
+  ports:
+    - port: 8080
+  selector:
+    app: {{ template "name" . }}
+    component: controller
+    release: {{ .Release.Name }}

--- a/alb-ingress-controller-helm/templates/controller-service.yaml
+++ b/alb-ingress-controller-helm/templates/controller-service.yaml
@@ -11,6 +11,9 @@ metadata:
     component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.controller.service.labels }}
+{{ toYaml .Values.controller.service.labels | indent 4 }}
+  {{- end }}
   name: {{ template "controller.fullname" . }}
 spec:
   ports:

--- a/alb-ingress-controller-helm/templates/default-backend-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/default-backend-deployment.yaml
@@ -20,6 +20,9 @@ spec:
         app: {{ template "name" . }}
         component: default-backend
         release: {{ .Release.Name }}
+      {{- if .Values.defaultBackend.podLabels }}
+{{ toYaml .Values.defaultBackend.podLabels | indent 8}}
+      {{- end }}
     spec:
       containers:
         - name: {{ template "name" . }}-default-backend

--- a/alb-ingress-controller-helm/templates/default-backend-service.yaml
+++ b/alb-ingress-controller-helm/templates/default-backend-service.yaml
@@ -11,6 +11,9 @@ metadata:
     component: default-backend
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.defaultBackend.service.labels }}
+{{ toYaml .Values.defaultBackend.service.labels | indent 4 }}
+  {{- end }}
   name: {{ template "defaultBackend.fullname" . }}
 spec:
   ports:

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -50,6 +50,9 @@ controller:
     #   cpu: 100m
     #   memory: 100Mi
 
+  service:
+    annotations: {}
+
 defaultBackend:
   image:
     repository: gcr.io/google_containers/defaultbackend

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -42,6 +42,8 @@ controller:
   podAnnotations: {}
     # iam.amazonaws.com/role: alb-ingress-controller
 
+  podLabels: {}
+
   resources: {}
     # limits:
     #   cpu: 100m
@@ -52,6 +54,9 @@ controller:
 
   service:
     annotations: {}
+      # prometheus.io/scrape: "true"
+
+    labels: {}
 
 defaultBackend:
   image:
@@ -64,6 +69,7 @@ defaultBackend:
     # tier: cs
 
   podAnnotations: {}
+  podLabels: {}
   replicaCount: 1
 
   resources: {}
@@ -76,6 +82,7 @@ defaultBackend:
 
   service:
     annotations: {}
+    labels: {}
 
 rbac:
   ## If true, create & use RBAC resources


### PR DESCRIPTION
Minor update to the Helm chart that eliminates redundancy if the release name is the same as the chart name.