### PR TITLE
Helm extraEnv value

### DIFF
--- a/alb-ingress-controller-helm/Chart.yaml
+++ b/alb-ingress-controller-helm/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 name: alb-ingress-controller-helm
 sources:
   - https://github.com/coreos/alb-ingress-controller
-version: 0.0.5
+version: 0.0.6

--- a/alb-ingress-controller-helm/README.md
+++ b/alb-ingress-controller-helm/README.md
@@ -44,14 +44,12 @@ The following tables lists the configurable parameters of the alb-ingress-contro
 
 Parameter | Description | Default
 --- | --- | ---
-`aws.accessKeyId` | If provided, AWS_ACCESS_KEY_ID environment variable will be set to this value | `""`
-`aws.secretAccessKey` | If provided, AWS_SECRET_ACCESS_KEY environment variable will be set to this value | `""`
-`aws.debug` | If true, enables logging on all outbound AWS API requests | `false`
-`aws.region` | (REQUIRED) AWS region in which this ingress controller will operate | `us-west-1`
+`awsRegion` | (REQUIRED) AWS region in which this ingress controller will operate | `us-west-1`
 `clusterName` | (REQUIRED) Resources created by the ALB Ingress controller will be prefixed with this string | `k8s`
 `controller.image.repository` | controller container image repository | `quay.io/coreos/alb-ingress-controller`
 `controller.image.tag` | controller container image tag | `0.8`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
+`controller.extraEnv` | map of environment variables to be injected into the controller pod | `{}`
 `controller.nodeSelector` | node labels for controller pod assignment | `{}`
 `controller.podAnnotations` | annotations to be added to controller pod | `{}`
 `controller.resources` | controller pod resource requests & limits | `{}`

--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -37,20 +37,14 @@ spec:
             - --watch-namespace={{ default .Release.Namespace .Values.scope.watchNamespace }}
           {{- end }}
           env:
-          {{- if .Values.aws.accessKeyId }}
-            - name: AWS_ACCESS_KEY_ID
-              value: "{{ .Values.aws.accessKeyId }}"
-          {{- end }}
-          {{- if .Values.aws.secretAccessKey }}
-            - name: AWS_SECRET_ACCESS_KEY
-              value: "{{ .Values.aws.secretAccessKey }}"
-          {{- end }}
-            - name: AWS_DEBUG
-              value: "{{ .Values.aws.debug }}"
             - name: AWS_REGION
-              value: "{{ .Values.aws.region }}"
+              value: "{{ .Values.awsRegion }}"
             - name: CLUSTER_NAME
               value: "{{ .Values.clusterName }}"
+          {{- range $key, $value := .Values.controller.extraEnv }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+          {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -4,25 +4,10 @@
 # overrides the chart name.
 nameOverride: alb-ingress-controller
 
-## Ref: https://github.com/coreos/alb-ingress-controller/blob/master/docs/configuration.md#aws-api-access
+## AWS region in which this ingress controller will operate
+## REQUIRED
 #
-aws:
-  ## If provided, AWS_ACCESS_KEY_ID environment variable will be set to this value
-  #
-  accessKeyId: ""
-
-  ## If provided, AWS_SECRET_ACCESS_KEY environment variable will be set to this value
-  #
-  secretAccessKey: ""
-
-  ## If true, enables logging on all outbound AWS API requests
-  #
-  debug: false
-
-  ## AWS region in which this ingress controller will operate
-  ## REQUIRED
-  #
-  region: us-west-1
+awsRegion: us-west-1
 
 ## Resources created by the ALB Ingress controller will be prefixed with this string
 ## REQUIRED
@@ -34,6 +19,13 @@ controller:
     repository: quay.io/coreos/alb-ingress-controller
     tag: "0.8"
     pullPolicy: IfNotPresent
+
+  extraEnv: {}
+    # AWS_ACCESS_KEY_ID: ""
+    # AWS_SECRET_ACCESS_KEY: ""
+    # AWS_DEBUG: false
+    # DISABLE_ROUTE53: false
+    # LOG_LEVEL: ""
 
   nodeSelector: {}
     # node-role.kubernetes.io/node: "true"


### PR DESCRIPTION
Rather than provide a value for every possible environment variable, use an `extraEnv` key:value map. Only `awsRegion` and `clusterName` remain independent, as they are required for every deployment.