### PR TITLE
Add configurable upstream ALB background sync

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 	albSyncInterval, err := time.ParseDuration(albSyncParam)
 	if err != nil {
-		log.Exitf("Failed to parse duration from ALB_SYNC_INTERVAL value of '%s'", albSyncParam)
+		logger.Exitf("Failed to parse duration from ALB_SYNC_INTERVAL value of '%s'", albSyncParam)
 	}
 
 	conf := &config.Config{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,7 +1,11 @@
 package config
 
+import "time"
+
 // Config contains the ALB Ingress Controller configuration
 type Config struct {
-	ClusterName string
-	AWSDebug    bool
+	ClusterName     string
+	AWSDebug        bool
+	DisableRoute53  bool
+	ALBSyncInterval time.Duration
 }


### PR DESCRIPTION
Makes alb-ingress-controller sync with ALBs in order to detect external changes to load balancers.