### PR TITLE
Prevent cluster IPs in ingress statuses

### DIFF
--- a/pkg/controller/alb-controller.go
+++ b/pkg/controller/alb-controller.go
@@ -279,7 +279,7 @@ func (ac *ALBController) UpdateIngressStatus(ing *extensions.Ingress) []api.Load
 		}
 	}
 
-	return nil
+	return []api.LoadBalancerIngress{}
 }
 
 // GetServiceNodePort returns the nodeport for a given Kubernetes service


### PR DESCRIPTION
- Ensure that we also return non-nil when the UpdateStatus callback fires.
This ensures that the ingress status will never contain internal cluster
IPs (that are sent back when nil is returned)

Waiting a bit to hear if this resolves issues in our sandbox cluster regarding external-dns.

I've also removed `pkg/controller/debug.test`, which must have been committed by accident at some point.