### PR TITLE
Stop reconciliation when targetgroup(s) fail

### DIFF
--- a/pkg/alb/loadbalancer/loadbalancer.go
+++ b/pkg/alb/loadbalancer/loadbalancer.go
@@ -201,6 +201,9 @@ func (lb *LoadBalancer) Reconcile(rOpts *ReconcileOptions) []error {
 	}
 	if tgs, err := lb.TargetGroups.Reconcile(tgsOpts); err != nil {
 		errors = append(errors, err)
+		// don't continue to listener reconciliation if targetgroup reconciliation
+		// failed.
+		return errors
 	} else {
 		lb.TargetGroups = tgs
 	}

--- a/pkg/alb/rule/rule.go
+++ b/pkg/alb/rule/rule.go
@@ -150,6 +150,10 @@ func (r *Rule) TargetGroupArn(tgs targetgroups.TargetGroups) *string {
 		r.logger.Errorf("Failed to locate TargetGroup related to this service: %s", r.svcName)
 		return nil
 	}
+	if tgs[i].Current == nil {
+		r.logger.Errorf("Located TargetGroup but no known (current) state found: %s", r.svcName)
+		return nil
+	}
 	return tgs[i].Current.TargetGroupArn
 }
 

--- a/pkg/albingress/albingress.go
+++ b/pkg/albingress/albingress.go
@@ -112,6 +112,8 @@ func NewALBIngressFromIngress(o *NewALBIngressFromIngressOptions) *ALBIngress {
 		newIngress = o.ExistingIngress
 		newIngress.lock.Lock()
 		defer newIngress.lock.Unlock()
+		// reattach k8s ingress as if assembly happened through aws sync, it may be missing.
+		newIngress.ingress = o.Ingress
 		// Ensure all desired state is removed from the copied ingress. The desired state of each
 		// component will be generated later in this function.
 		newIngress.StripDesiredState()

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -182,6 +182,11 @@ func (a *Annotations) setHealthcheckTimeoutSeconds(annotations map[string]string
 		a.HealthcheckTimeoutSeconds = aws.Int64(5)
 		return nil
 	}
+	// If interval is set at our above timeout, AWS will reject targetgroup creation
+	if i >= *a.HealthcheckIntervalSeconds {
+		return fmt.Errorf("Healthcheck timeout must be less than healthcheck interval. Timeout was: %d. Interval was %d.",
+			i, *a.HealthcheckIntervalSeconds)
+	}
 	a.HealthcheckTimeoutSeconds = &i
 	return nil
 }

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -39,3 +39,15 @@ func TestSetScheme(t *testing.T) {
 		}
 	}
 }
+
+// Should fail to create due to healthchecktimeout being greater than HealthcheckIntervalSeconds
+func TestHealthcheckSecondsValidation(t *testing.T) {
+	a := &Annotations{}
+	if err := a.setHealthcheckIntervalSeconds(map[string]string{healthcheckIntervalSecondsKey: "5"}); err != nil {
+		t.Errorf("Unexpected error seting HealthcheckIntervalSeconds. Error: %s", err.Error())
+	}
+
+	if err := a.setHealthcheckTimeoutSeconds(map[string]string{healthcheckTimeoutSecondsKey: "10"}); err == nil {
+		t.Errorf("Set healthchecktimeoutSeconds when it should have failed due to being higher than HealthcheckIntervalSeconds")
+	}
+}


### PR DESCRIPTION
- If reconciliation of a targetgroup fails don't continue to listener
reconciliation. Otherwise looking up the current state of the
targetgroup could cause a panic.

- Additionally, make the targetgroup resolution more resilient such that
it doesn't panic when the Current state is unknown.

- Resolves: https://github.com/coreos/alb-ingress-controller/issues/242