### PR TITLE
Support connection idle timeout

### DIFF
--- a/docs/ingress-resources.md
+++ b/docs/ingress-resources.md
@@ -52,6 +52,7 @@ Required annotations are:
 ```
 alb.ingress.kubernetes.io/backend-protocol
 alb.ingress.kubernetes.io/certificate-arn
+alb.ingress.kubernetes.io/connection-idle-timeout
 alb.ingress.kubernetes.io/healthcheck-interval-seconds
 alb.ingress.kubernetes.io/healthcheck-path
 alb.ingress.kubernetes.io/healthcheck-port
@@ -71,6 +72,8 @@ Optional annotations are:
 - **backend-protocol**: Enables selection of protocol for ALB to use to connect to backend service. When omitted, `HTTP` is used.
 
 - **certificate-arn**: Enables HTTPS and uses the certificate defined, based on arn, stored in your [AWS Certificate Manager](https://aws.amazon.com/certificate-manager).
+
+- **connection-idle-timeout**: Sets the connection idle timeout setting for the ALB. This is a global setting for the ALB.
 
 - **healthcheck-interval-seconds**: The approximate amount of time, in seconds, between health checks of an individual target. The default is 15 seconds.
 

--- a/pkg/albingress/albingress.go
+++ b/pkg/albingress/albingress.go
@@ -80,13 +80,14 @@ func NewALBIngress(o *NewALBIngressOptions) *ALBIngress {
 }
 
 type NewALBIngressFromIngressOptions struct {
-	Ingress            *extensions.Ingress
-	ExistingIngress    *ALBIngress
-	ClusterName        string
-	ALBNamePrefix      string
-	GetServiceNodePort func(string, int32) (*int64, error)
-	GetNodes           func() util.AWSStringSlice
-	Recorder           record.EventRecorder
+	Ingress               *extensions.Ingress
+	ExistingIngress       *ALBIngress
+	ClusterName           string
+	ALBNamePrefix         string
+	GetServiceNodePort    func(string, int32) (*int64, error)
+	GetNodes              func() util.AWSStringSlice
+	Recorder              record.EventRecorder
+	ConnectionIdleTimeout int64
 }
 
 // NewALBIngressFromIngress builds ALBIngress's based off of an Ingress object
@@ -191,12 +192,13 @@ func NewALBIngressFromIngress(o *NewALBIngressFromIngressOptions) *ALBIngress {
 }
 
 type NewALBIngressFromAWSLoadBalancerOptions struct {
-	LoadBalancer      *elbv2.LoadBalancer
-	ALBNamePrefix     string
-	Recorder          record.EventRecorder
-	ManagedSG         *string
-	ManagedSGPorts    []int64
-	ManagedInstanceSG *string
+	LoadBalancer          *elbv2.LoadBalancer
+	ALBNamePrefix         string
+	Recorder              record.EventRecorder
+	ManagedSG             *string
+	ManagedSGPorts        []int64
+	ManagedInstanceSG     *string
+	ConnectionIdleTimeout int64
 }
 
 // NewALBIngressFromAWSLoadBalancer builds ALBIngress's based off of an elbv2.LoadBalancer
@@ -228,13 +230,14 @@ func NewALBIngressFromAWSLoadBalancer(o *NewALBIngressFromAWSLoadBalancerOptions
 
 	// Assemble load balancer
 	ingress.LoadBalancer, err = loadbalancer.NewCurrentLoadBalancer(&loadbalancer.NewCurrentLoadBalancerOptions{
-		LoadBalancer:      o.LoadBalancer,
-		Tags:              tags,
-		ALBNamePrefix:     o.ALBNamePrefix,
-		Logger:            ingress.logger,
-		ManagedSG:         o.ManagedSG,
-		ManagedSGPorts:    o.ManagedSGPorts,
-		ManagedInstanceSG: o.ManagedInstanceSG,
+		LoadBalancer:          o.LoadBalancer,
+		Tags:                  tags,
+		ALBNamePrefix:         o.ALBNamePrefix,
+		Logger:                ingress.logger,
+		ManagedSG:             o.ManagedSG,
+		ManagedSGPorts:        o.ManagedSGPorts,
+		ManagedInstanceSG:     o.ManagedInstanceSG,
+		ConnectionIdleTimeout: o.ConnectionIdleTimeout,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -51,3 +51,18 @@ func TestHealthcheckSecondsValidation(t *testing.T) {
 		t.Errorf("Set healthchecktimeoutSeconds when it should have failed due to being higher than HealthcheckIntervalSeconds")
 	}
 }
+
+// Should fail when idle timeout is not in range 1-3600. Should succeed otherwise.
+func TestConnectionIdleTimeoutValidation(t *testing.T) {
+	a := &Annotations{}
+
+	err := a.setConnectionIdleTimeout(map[string]string{connectionIdleTimeoutKey: "15"})
+	if err != nil || a.ConnectionIdleTimeout == 0 {
+		t.Error("Failed to set connection idle timeout when value was correct.")
+	}
+
+	err = a.setConnectionIdleTimeout(map[string]string{connectionIdleTimeoutKey: "3700"})
+	if err == nil {
+		t.Error("Succeeded setting connection idle timeout when value was incorrect")
+	}
+}

--- a/pkg/controller/alb-controller.go
+++ b/pkg/controller/alb-controller.go
@@ -101,8 +101,8 @@ func (ac *ALBController) Configure(ic *controller.GenericController) {
 
 func (ac *ALBController) startPolling() {
 	for {
-		time.Sleep(60 * time.Second)
-		if ac.lastUpdate.Add(180 * time.Second).Before(time.Now()) {
+		time.Sleep(10 * time.Second)
+		if ac.lastUpdate.Add(60 * time.Second).Before(time.Now()) {
 			logger.Debugf("Forcing ingress update as update hasn't occured in 3 minutes.")
 			ac.update()
 		}

--- a/pkg/util/types/types.go
+++ b/pkg/util/types/types.go
@@ -14,6 +14,10 @@ import (
 	"github.com/coreos/alb-ingress-controller/pkg/util/log"
 )
 
+const (
+	IdleTimeoutKey = "idle_timeout.timeout_seconds"
+)
+
 type AWSStringSlice []*string
 type Tags []*elbv2.Tag
 type EC2Tags []*ec2.Tag


### PR DESCRIPTION
- Adds annotation to support connection idle timeout on ALB.

- Resolves https://github.com/coreos/alb-ingress-controller/issues/79