### PR TITLE
Fix TargetGroup and Rule reconciliation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 
 all: container
 
-TAG?=1.0-alpha.3
+TAG?=1.0-alpha.5
 PREFIX?=quay.io/coreos/alb-ingress-controller
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)

--- a/pkg/alb/listener/listener_test.go
+++ b/pkg/alb/listener/listener_test.go
@@ -242,7 +242,7 @@ func TestModificationNeeds(t *testing.T) {
 		Current: mockList1,
 	}
 
-	if !lPortNeedsMod.NeedsModification(lPortNeedsMod.Desired) {
+	if !lPortNeedsMod.NeedsModificationCheck(lPortNeedsMod.Desired) {
 		t.Error("Listener reported no modification needed. Ports were different and should" +
 			"require modification")
 	}
@@ -253,7 +253,7 @@ func TestModificationNeeds(t *testing.T) {
 		Current: mockList1,
 	}
 
-	if lNoMod.NeedsModification(lNoMod.Desired) {
+	if lNoMod.NeedsModificationCheck(lNoMod.Desired) {
 		t.Error("Listener reported modification needed. Desired and Current were the same")
 	}
 
@@ -263,7 +263,7 @@ func TestModificationNeeds(t *testing.T) {
 		Current: mockList1,
 	}
 
-	if !lCertNeedsMod.NeedsModification(lCertNeedsMod.Desired) {
+	if !lCertNeedsMod.NeedsModificationCheck(lCertNeedsMod.Desired) {
 		t.Error("Listener reported no modification needed. Certificates were different and" +
 			"should require modification")
 	}

--- a/pkg/alb/rule/rule_test.go
+++ b/pkg/alb/rule/rule_test.go
@@ -27,7 +27,7 @@ func TestNewDesiredRule(t *testing.T) {
 			Path:     "/path",
 			SvcName:  "namespace-service",
 			ExpectedRule: Rule{
-				svcName: "namespace-service",
+				DesiredSvcName: "namespace-service",
 				Desired: &elbv2.Rule{
 					Priority:  aws.String("default"),
 					IsDefault: aws.Bool(true),
@@ -41,7 +41,7 @@ func TestNewDesiredRule(t *testing.T) {
 			Path:     "/path",
 			SvcName:  "namespace-service",
 			ExpectedRule: Rule{
-				svcName: "namespace-service",
+				DesiredSvcName: "namespace-service",
 				Desired: &elbv2.Rule{
 					Priority:  aws.String("1"),
 					IsDefault: aws.Bool(false),
@@ -105,15 +105,15 @@ func TestReconcile(t *testing.T) {
 	}{
 		{ // test empty rule, no current/desired rules
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 			},
 			Pass: true,
 		},
 		{ // test Current is default, doesnt delete
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 				Current: &elbv2.Rule{
 					Priority:  aws.String("default"),
 					IsDefault: aws.Bool(true),
@@ -124,8 +124,8 @@ func TestReconcile(t *testing.T) {
 		},
 		{ // test delete
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 				Current: &elbv2.Rule{
 					Priority:  aws.String("1"),
 					IsDefault: aws.Bool(false),
@@ -136,8 +136,8 @@ func TestReconcile(t *testing.T) {
 		},
 		{ // test delete, fail
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 				Current: &elbv2.Rule{
 					Priority:  aws.String("1"),
 					IsDefault: aws.Bool(false),
@@ -149,8 +149,8 @@ func TestReconcile(t *testing.T) {
 		},
 		{ // test desired rule is default, we do nothing
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 				Desired: &elbv2.Rule{
 					Priority:  aws.String("default"),
 					IsDefault: aws.Bool(true),
@@ -161,8 +161,8 @@ func TestReconcile(t *testing.T) {
 		},
 		{ // test current rule is nil, desired rule exists, runs create
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 				Desired: &elbv2.Rule{
 					Priority:  aws.String("1"),
 					IsDefault: aws.Bool(false),
@@ -180,8 +180,8 @@ func TestReconcile(t *testing.T) {
 		},
 		{ // test current rule is nil, desired rule exists, runs create, fails
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 				Desired: &elbv2.Rule{
 					Priority:  aws.String("1"),
 					IsDefault: aws.Bool(false),
@@ -200,8 +200,8 @@ func TestReconcile(t *testing.T) {
 		},
 		{ // test current rule and desired rule are different, modify current rule
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 				Current: &elbv2.Rule{
 					Priority:  aws.String("1"),
 					IsDefault: aws.Bool(false),
@@ -236,8 +236,8 @@ func TestReconcile(t *testing.T) {
 		},
 		{ // test current rule and desired rule are different, modify current rule, fail
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 				Current: &elbv2.Rule{
 					Priority:  aws.String("1"),
 					IsDefault: aws.Bool(false),
@@ -274,8 +274,8 @@ func TestReconcile(t *testing.T) {
 		},
 		{ // test current rule and desired rule are the same, default case
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 				Current: &elbv2.Rule{
 					Priority:  aws.String("1"),
 					IsDefault: aws.Bool(false),
@@ -341,16 +341,6 @@ func TestTargetGroupArn(t *testing.T) {
 		TargetGroups targetgroups.TargetGroups
 		Rule         Rule
 	}{
-		{ // Current rule already contains the TG, ignore the TargetGroups param
-			Expected: aws.String(":)"),
-			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
-				Current: &elbv2.Rule{
-					Actions: []*elbv2.Action{{TargetGroupArn: aws.String(":)")}},
-				},
-			},
-		},
 		{ // svcname is found in the targetgroups list, returns the targetgroup arn
 			Expected: aws.String(":)"),
 			TargetGroups: targetgroups.TargetGroups{
@@ -362,8 +352,8 @@ func TestTargetGroupArn(t *testing.T) {
 				},
 			},
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 			},
 		},
 		{ // svcname isn't found in targetgroups list, returns a nil
@@ -374,8 +364,8 @@ func TestTargetGroupArn(t *testing.T) {
 				},
 			},
 			Rule: Rule{
-				svcName: "namespace-service",
-				logger:  log.New("test"),
+				DesiredSvcName: "namespace-service",
+				logger:         log.New("test"),
 			},
 		},
 	}

--- a/pkg/alb/targetgroups/targetgroups.go
+++ b/pkg/alb/targetgroups/targetgroups.go
@@ -28,7 +28,7 @@ func (t TargetGroups) LookupBySvc(svc string) int {
 	return -1
 }
 
-// Find returns the position of a TargetGroup by its ID, returning -1 if unfound.
+// FindById returns the position of a TargetGroup by its ID, returning -1 if unfound.
 func (t TargetGroups) FindById(id string) (int, *targetgroup.TargetGroup) {
 	for p, v := range t {
 		if v.ID == id {
@@ -38,10 +38,22 @@ func (t TargetGroups) FindById(id string) (int, *targetgroup.TargetGroup) {
 	return -1, nil
 }
 
+// FindCurrentByARN returns the position of a current TargetGroup and the TargetGroup itself based on the ARN passed. Returns the position of -1 if unfound.
+func (t TargetGroups) FindCurrentByARN(id string) (int, *targetgroup.TargetGroup) {
+	for p, v := range t {
+		if *v.Current.TargetGroupArn == id {
+			return p, v
+		}
+	}
+	return -1, nil
+}
+
 // Reconcile kicks off the state synchronization for every target group inside this TargetGroups
-// instance.
-func (t TargetGroups) Reconcile(rOpts *ReconcileOptions) (TargetGroups, error) {
+// instance. It returns the new TargetGroups its created and a list of TargetGroups it believes
+// should be cleaned up.
+func (t TargetGroups) Reconcile(rOpts *ReconcileOptions) (TargetGroups, TargetGroups, error) {
 	var output TargetGroups
+	var cleanUp TargetGroups
 	for _, tg := range t {
 		tgOpts := &targetgroup.ReconcileOptions{
 			Eventf:            rOpts.Eventf,
@@ -49,14 +61,15 @@ func (t TargetGroups) Reconcile(rOpts *ReconcileOptions) (TargetGroups, error) {
 			ManagedSGInstance: rOpts.ManagedSGInstance,
 		}
 		if err := tg.Reconcile(tgOpts); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		if !tg.Deleted {
-			output = append(output, tg)
+		if tg.Deleted {
+			cleanUp = append(cleanUp, tg)
 		}
+		output = append(output, tg)
 	}
 
-	return output, nil
+	return output, cleanUp, nil
 }
 
 // StripDesiredState removes the Tags.Desired, DesiredTargetGroup, and Targets.Desired from all TargetGroups

--- a/pkg/albingress/albingress.go
+++ b/pkg/albingress/albingress.go
@@ -266,8 +266,9 @@ func NewALBIngressFromAWSLoadBalancer(o *NewALBIngressFromAWSLoadBalancerOptions
 	}
 
 	ingress.LoadBalancer.Listeners, err = listeners.NewCurrentListeners(&listeners.NewCurrentListenersOptions{
-		Listeners: ls,
-		Logger:    ingress.logger,
+		TargetGroups: &ingress.LoadBalancer.TargetGroups,
+		Listeners:    ls,
+		Logger:       ingress.logger,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/albingresses/albingresses.go
+++ b/pkg/albingresses/albingresses.go
@@ -155,10 +155,11 @@ func AssembleIngressesFromAWS(o *AssembleIngressesFromAWSOptions) ALBIngresses {
 				ConnectionIdleTimeout: idleTimeout,
 			})
 			if err != nil {
-				logger.Fatalf(err.Error())
+				logger.Infof(err.Error())
+			} else {
+				ingresses = append(ingresses, albIngress)
 			}
 
-			ingresses = append(ingresses, albIngress)
 		}(&wg, loadBalancer)
 	}
 	wg.Wait()

--- a/pkg/controller/alb-controller.go
+++ b/pkg/controller/alb-controller.go
@@ -103,7 +103,7 @@ func (ac *ALBController) startPolling() {
 	for {
 		time.Sleep(10 * time.Second)
 		if ac.lastUpdate.Add(60 * time.Second).Before(time.Now()) {
-			logger.Debugf("Forcing ingress update as update hasn't occured in 3 minutes.")
+			logger.Infof("Forcing ingress update as update hasn't occured in 3 minutes.")
 			ac.update()
 		}
 	}
@@ -112,7 +112,7 @@ func (ac *ALBController) startPolling() {
 func (ac *ALBController) syncALBs() {
 	for {
 		time.Sleep(ac.albSyncInterval)
-		logger.Debugf("ALB sync interval %s elapsed; assembling ingresses..", ac.albSyncInterval)
+		logger.Debugf("ALB sync interval %s elapsed; Assembly will be reattempted once lock is available..", ac.albSyncInterval)
 		ac.syncALBsWithAWS()
 	}
 }
@@ -120,6 +120,7 @@ func (ac *ALBController) syncALBs() {
 func (ac *ALBController) syncALBsWithAWS() {
 	ac.mutex.Lock()
 	defer ac.mutex.Unlock()
+	logger.Debugf("Lock was available. Attempting sync")
 	ac.ALBIngresses = albingresses.AssembleIngressesFromAWS(&albingresses.AssembleIngressesFromAWSOptions{
 		Recorder:      ac.recorder,
 		ALBNamePrefix: ac.albNamePrefix,

--- a/pkg/controller/alb-controller.go
+++ b/pkg/controller/alb-controller.go
@@ -103,7 +103,7 @@ func (ac *ALBController) startPolling() {
 	for {
 		time.Sleep(10 * time.Second)
 		if ac.lastUpdate.Add(60 * time.Second).Before(time.Now()) {
-			logger.Infof("Forcing ingress update as update hasn't occured in 3 minutes.")
+			logger.Infof("Ingress update being attempted. (Forced from no event seen in 60 seconds).")
 			ac.update()
 		}
 	}


### PR DESCRIPTION
- TargetGroups and rules now reconcile correctly adding the following
correct behaviors.

    - Unused TGs are deleted

    - When a new service is pointed to, the existing rules are updates with
the new service's TG