### PR TITLE
Ensure that load balancer name consists of valid characters

### DIFF
--- a/pkg/alb/loadbalancer/loadbalancer.go
+++ b/pkg/alb/loadbalancer/loadbalancer.go
@@ -5,8 +5,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -73,8 +73,7 @@ func (a portList) Less(i, j int) bool { return a[i] < a[j] }
 
 // NewDesiredLoadBalancer returns a new loadbalancer.LoadBalancer based on the parameters provided.
 func NewDesiredLoadBalancer(o *NewDesiredLoadBalancerOptions) *LoadBalancer {
-	// TODO: LB name  must contain only alphanumeric characters or hyphens, and must
-	// not begin or end with a hyphen.
+	// TODO: LB name must not begin with a hyphen.
 	name := createLBName(o.Namespace, o.IngressName, o.ALBNamePrefix)
 
 	newLoadBalancer := &LoadBalancer{
@@ -597,10 +596,12 @@ func createLBName(namespace string, ingressName string, clustername string) stri
 	hasher := md5.New()
 	hasher.Write([]byte(namespace + ingressName))
 	hash := hex.EncodeToString(hasher.Sum(nil))[:4]
+
+	r, _ := regexp.Compile("[[:^alnum:]]")
 	name := fmt.Sprintf("%s-%s-%s",
-		clustername,
-		strings.Replace(namespace, "-", "", -1),
-		strings.Replace(ingressName, "-", "", -1),
+		r.ReplaceAllString(clustername, "-"),
+		r.ReplaceAllString(namespace, ""),
+		r.ReplaceAllString(ingressName, ""),
 	)
 	if len(name) > 26 {
 		name = name[:26]


### PR DESCRIPTION
Ran into an issue where clusters with "."'s in their name could run afoul of the valid naming scheme for load balancers.

This fix ensures that any invalid (non-alphanumeric) characters in the namespace or ingress name are removed and that any invalid (non-alphanumeric) characters in the cluster name are replaced with "-"'s.