### PR TITLE
add http probes and remove traces of route53

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PREFIX?=quay.io/coreos/alb-ingress-controller
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 
-server: cmd/main.go
+server: cmd/main.go pkg/*/*.go pkg/*/*/*.go
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GOARM=6 go build -a -installsuffix cgo -ldflags '-w' -o server cmd/main.go
 
 container: server

--- a/alb-ingress-controller-helm/Chart.yaml
+++ b/alb-ingress-controller-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 0.8
-description: The ALB Ingress Controller satisfies Kubernetes ingress resources by provisioning Application Load Balancers and Route53 Resource Record Sets.
+description: The ALB Ingress Controller satisfies Kubernetes ingress resources by provisioning Application Load Balancers.
 engine: gotpl
 home: https://github.com/coreos/alb-ingress-controller
 keywords:
@@ -16,4 +16,4 @@ maintainers:
 name: alb-ingress-controller-helm
 sources:
   - https://github.com/coreos/alb-ingress-controller
-version: 0.0.6
+version: 0.0.7

--- a/alb-ingress-controller-helm/README.md
+++ b/alb-ingress-controller-helm/README.md
@@ -1,6 +1,6 @@
 # alb-ingress-controller
 
-[alb-ingress-controller](https://github.com/coreos/alb-ingress-controller) satisfies Kubernetes ingress resources by provisioning Application Load Balancers and Route53 Resource Record Sets.
+[alb-ingress-controller](https://github.com/coreos/alb-ingress-controller) satisfies Kubernetes ingress resources by provisioning Application Load Balancers.
 
 ## TL;DR:
 

--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -61,6 +61,7 @@ spec:
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 30
+          periodSeconds: 60
         readinessProbe:
           httpGet:
             path: /healthz

--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -55,6 +55,18 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 15
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -24,7 +24,6 @@ controller:
     # AWS_ACCESS_KEY_ID: ""
     # AWS_SECRET_ACCESS_KEY: ""
     # AWS_DEBUG: false
-    # DISABLE_ROUTE53: false
     # LOG_LEVEL: ""
 
   nodeSelector: {}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ func main() {
 	ac.Configure(ic)
 
 	http.HandleFunc("/state", ac.StateHandler)
+	http.HandleFunc("/healthz", ac.StatusHandler)
 
 	defer func() {
 		logger.Infof("Shutting down ingress controller...")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,13 +5,13 @@ This document covers configuration of the ALB Ingress Controller.
 ## AWS API Access
 
 To perform operations, the controller must have requred IAM role capabilities for accessing and
-provisioning ALB and Route53 resources. There are many ways to achieve this, such as loading `AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY` as environment variables or using [kube2iam](https://github.com/jtblin/kube2iam). 
+provisioning ALB resources. There are many ways to achieve this, such as loading `AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY` as environment variables or using [kube2iam](https://github.com/jtblin/kube2iam).
 
-A sample IAM policy, with the minimum permissions to run the controller, can be found in [examples/alb-iam-policy.json](../examples/iam-policy.json).  
+A sample IAM policy, with the minimum permissions to run the controller, can be found in [examples/alb-iam-policy.json](../examples/iam-policy.json).
 
 ## Setting Ingress Resource Scope
 
-By default, all ingress resources in your cluster are seen by the controller. However, only ingress resources that contain the [required annotations](https://github.com/coreos/alb-ingress-controller/blob/master/docs/ingress-resources.md#required-annotations) will be satisfied by the ALB Ingress Controller. 
+By default, all ingress resources in your cluster are seen by the controller. However, only ingress resources that contain the [required annotations](https://github.com/coreos/alb-ingress-controller/blob/master/docs/ingress-resources.md#required-annotations) will be satisfied by the ALB Ingress Controller.
 
 You can further limit the ingresses your controller has access to. The options available are limiting the ingress class  (`ingress.class`) or limiting the namespace watched (`--watch-namespace=`). Each approach is detailed below.
 
@@ -33,17 +33,17 @@ spec:
 Now, only ingress resources with the appropriate annotation are picked up, as seen below.
 
 ```yaml
-apiVersion: extensions/v1beta1                                                                 
-kind: Ingress                                                                                  
-metadata:                                                                                      
-  name: echoserver                                                                             
-  namespace: echoserver                                                                        
-  annotations:                                                                                 
-    alb.ingress.kubernetes.io/port: "8080,9000"                                                
-    alb.ingress.kubernetes.io/subnets: subnet-63bf6318,subnet-0b20aa62                         
-    alb.ingress.kubernetes.io/security-groups: sg-1f84f776                                     
-    kubernetes.io/ingress.class: "alb"                                                         
-spec:                                    
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: echoserver
+  namespace: echoserver
+  annotations:
+    alb.ingress.kubernetes.io/port: "8080,9000"
+    alb.ingress.kubernetes.io/subnets: subnet-63bf6318,subnet-0b20aa62
+    alb.ingress.kubernetes.io/security-groups: sg-1f84f776
+    kubernetes.io/ingress.class: "alb"
+spec:
 	...
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@ This document covers configuration of the ALB Ingress Controller.
 
 ## AWS API Access
 
-To perform operations, the controller must have requred IAM role capabilities for accessing and
+To perform operations, the controller must have required IAM role capabilities for accessing and
 provisioning ALB resources. There are many ways to achieve this, such as loading `AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY` as environment variables or using [kube2iam](https://github.com/jtblin/kube2iam).
 
 A sample IAM policy, with the minimum permissions to run the controller, can be found in [examples/alb-iam-policy.json](../examples/iam-policy.json).

--- a/examples/iam-policy.json
+++ b/examples/iam-policy.json
@@ -4,16 +4,24 @@
         {
             "Effect": "Allow",
             "Action": [
+                "acm:DescribeCertificate",
+                "acm:ListCertificates"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:CreateSecurityGroup",
+                "ec2:CreateTags",
                 "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DeleteSecurityGroup",
+                "ec2:DescribeSubnets",
                 "ec2:DescribeTags",
                 "ec2:ModifyInstanceAttribute",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeInstances",
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:RevokeSecurityGroupIngress",
-                "ec2:DeleteSecurityGroup",
-                "ec2:CreateTags",
-                "ec2:CreateSecurityGroup"
+                "ec2:RevokeSecurityGroupIngress"
             ],
             "Resource": "*"
         },
@@ -21,56 +29,23 @@
             "Effect": "Allow",
             "Action": [
                 "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
-                "elasticloadbalancing:AttachLoadBalancerToSubnets",
-                "elasticloadbalancing:ConfigureHealthCheck",
-                "elasticloadbalancing:CreateListener",
-                "elasticloadbalancing:CreateLoadBalancer",
-                "elasticloadbalancing:CreateLoadBalancerListeners",
-                "elasticloadbalancing:CreateRule",
-                "elasticloadbalancing:CreateTargetGroup",
                 "elasticloadbalancing:DeleteListener",
-                "elasticloadbalancing:DeleteLoadBalancer",
-                "elasticloadbalancing:DeleteLoadBalancerListeners",
-                "elasticloadbalancing:DeleteRule",
                 "elasticloadbalancing:DeleteTargetGroup",
                 "elasticloadbalancing:DescribeListeners",
                 "elasticloadbalancing:DescribeLoadBalancers",
-                "elasticloadbalancing:DescribeRules",
                 "elasticloadbalancing:DescribeTags",
-                "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:ModifyListener",
                 "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                "elasticloadbalancing:ModifyRule",
-                "elasticloadbalancing:ModifyTargetGroup",
-                "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-                "elasticloadbalancing:RemoveTags",
-                "elasticloadbalancing:SetLoadBalancerListenerSSLCertificate",
-                "elasticloadbalancing:SetSecurityGroups",
-                "elasticloadbalancing:SetSubnets"
+                "elasticloadbalancing:RemoveTags"
             ],
             "Resource": "*"
         },
         {
             "Effect": "Allow",
             "Action": [
-                "route53:ChangeResourceRecordSets",
-                "route53:GetChange",
-                "route53:GetHostedZone",
-                "route53:ListHostedZones",
-                "route53:ListHostedZonesByName",
-                "route53:ListResourceRecordSets"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "acm:DescribeCertificate"
+                "iam:GetServerCertificate",
+                "iam:ListServerCertificates"
             ],
             "Resource": "*"
         }

--- a/examples/iam-policy.json
+++ b/examples/iam-policy.json
@@ -4,24 +4,16 @@
         {
             "Effect": "Allow",
             "Action": [
-                "acm:DescribeCertificate",
-                "acm:ListCertificates"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:CreateSecurityGroup",
-                "ec2:CreateTags",
                 "ec2:DescribeSecurityGroups",
-                "ec2:DescribeInstances",
-                "ec2:DeleteSecurityGroup",
-                "ec2:DescribeSubnets",
                 "ec2:DescribeTags",
                 "ec2:ModifyInstanceAttribute",
-                "ec2:RevokeSecurityGroupIngress"
+                "ec2:DescribeSubnets",
+                "ec2:DescribeInstances",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup",
+                "ec2:CreateTags",
+                "ec2:CreateSecurityGroup"
             ],
             "Resource": "*"
         },
@@ -29,23 +21,45 @@
             "Effect": "Allow",
             "Action": [
                 "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+                "elasticloadbalancing:AttachLoadBalancerToSubnets",
+                "elasticloadbalancing:ConfigureHealthCheck",
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateLoadBalancerListeners",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:CreateTargetGroup",
                 "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:DeleteLoadBalancerListeners",
+                "elasticloadbalancing:DeleteRule",
                 "elasticloadbalancing:DeleteTargetGroup",
                 "elasticloadbalancing:DescribeListeners",
                 "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeRules",
                 "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:ModifyListener",
                 "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                "elasticloadbalancing:RemoveTags"
+                "elasticloadbalancing:ModifyRule",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                "elasticloadbalancing:RemoveTags",
+                "elasticloadbalancing:SetLoadBalancerListenerSSLCertificate",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets"
             ],
             "Resource": "*"
         },
         {
             "Effect": "Allow",
             "Action": [
-                "iam:GetServerCertificate",
-                "iam:ListServerCertificates"
+                "acm:DescribeCertificate",
+                "acm:ListCertificates"
             ],
             "Resource": "*"
         }

--- a/glide.lock
+++ b/glide.lock
@@ -37,8 +37,6 @@ imports:
   - service/elbv2/elbv2iface
   - service/iam
   - service/iam/iamiface
-  - service/route53
-  - service/route53/route53iface
   - service/sts
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,8 +27,6 @@ import:
   - service/elbv2/elbv2iface
   - service/iam
   - service/iam/iamiface
-  - service/route53
-  - service/route53/route53iface
   - service/acm
   - service/acm/acmiface
 - package: github.com/golang/glog

--- a/pkg/aws/acm/acm.go
+++ b/pkg/aws/acm/acm.go
@@ -28,3 +28,16 @@ func (a *ACM) CertExists(arn *string) bool {
 	}
 	return true
 }
+
+// Status validates ACM connectivity
+func (a *ACM) Status() func() error {
+	return func() error {
+		in := &acm.ListCertificatesInput{}
+		in.SetMaxItems(6)
+
+		if _, err := a.ListCertificates(in); err != nil {
+			return err
+		}
+		return nil
+	}
+}

--- a/pkg/aws/acm/acm.go
+++ b/pkg/aws/acm/acm.go
@@ -33,7 +33,7 @@ func (a *ACM) CertExists(arn *string) bool {
 func (a *ACM) Status() func() error {
 	return func() error {
 		in := &acm.ListCertificatesInput{}
-		in.SetMaxItems(6)
+		in.SetMaxItems(1)
 
 		if _, err := a.ListCertificates(in); err != nil {
 			return err

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -506,5 +506,17 @@ func (e *EC2) GetVPCID(subnets []*string) (*string, error) {
 	}
 
 	return vpc, nil
+}
 
+// Status validates EC2 connectivity
+func (e *EC2) Status() func() error {
+	return func() error {
+		in := &ec2.DescribeTagsInput{}
+		in.SetMaxResults(6)
+
+		if _, err := e.DescribeTags(in); err != nil {
+			return err
+		}
+		return nil
+	}
 }

--- a/pkg/aws/elbv2/elbv2.go
+++ b/pkg/aws/elbv2/elbv2.go
@@ -254,7 +254,7 @@ func (e *ELBV2) UpdateTags(arn *string, old util.Tags, new util.Tags) error {
 func (e *ELBV2) Status() func() error {
 	return func() error {
 		in := &elbv2.DescribeLoadBalancersInput{}
-		in.SetPageSize(6)
+		in.SetPageSize(1)
 
 		if _, err := e.DescribeLoadBalancers(in); err != nil {
 			return err

--- a/pkg/aws/elbv2/elbv2.go
+++ b/pkg/aws/elbv2/elbv2.go
@@ -38,6 +38,7 @@ type ELBV2API interface {
 	RemoveListener(in elbv2.DeleteListenerInput) error
 	DescribeTargetGroupsForLoadBalancer(loadBalancerArn *string) ([]*elbv2.TargetGroup, error)
 	DescribeListenersForLoadBalancer(loadBalancerArn *string) ([]*elbv2.Listener, error)
+	Status() func() error
 }
 
 // ELBV2 is our extension to AWS's elbv2.ELBV2
@@ -247,4 +248,17 @@ func (e *ELBV2) UpdateTags(arn *string, old util.Tags, new util.Tags) error {
 	}
 
 	return nil
+}
+
+// Status validates ELBV2 connectivity
+func (e *ELBV2) Status() func() error {
+	return func() error {
+		in := &elbv2.DescribeLoadBalancersInput{}
+		in.SetPageSize(6)
+
+		if _, err := e.DescribeLoadBalancers(in); err != nil {
+			return err
+		}
+		return nil
+	}
 }

--- a/pkg/aws/iam/iam.go
+++ b/pkg/aws/iam/iam.go
@@ -41,7 +41,7 @@ func (i *IAM) CertExists(arn *string) bool {
 func (i *IAM) Status() func() error {
 	return func() error {
 		in := &iam.ListServerCertificatesInput{}
-		in.SetMaxItems(6)
+		in.SetMaxItems(1)
 
 		if _, err := i.ListServerCertificates(in); err != nil {
 			return err

--- a/pkg/aws/iam/iam.go
+++ b/pkg/aws/iam/iam.go
@@ -36,3 +36,16 @@ func (i *IAM) CertExists(arn *string) bool {
 	}
 	return true
 }
+
+// Status validates IAM connectivity
+func (i *IAM) Status() func() error {
+	return func() error {
+		in := &iam.ListServerCertificatesInput{}
+		in.SetMaxItems(6)
+
+		if _, err := i.ListServerCertificates(in); err != nil {
+			return err
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
Documentation worthy changes include the inclusion of action `acm:ListCertificates` to the IAM policy, added for the sake of health checking.