### PR TITLE
less permissive iam policy per current set of method calls

### DIFF
--- a/examples/iam-policy.json
+++ b/examples/iam-policy.json
@@ -4,16 +4,24 @@
         {
             "Effect": "Allow",
             "Action": [
+                "acm:DescribeCertificate",
+                "acm:ListCertificates"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:CreateSecurityGroup",
+                "ec2:CreateTags",
+                "ec2:DeleteSecurityGroup",
+                "ec2:DescribeInstances",
                 "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSubnets",
                 "ec2:DescribeTags",
                 "ec2:ModifyInstanceAttribute",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeInstances",
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:RevokeSecurityGroupIngress",
-                "ec2:DeleteSecurityGroup",
-                "ec2:CreateTags",
-                "ec2:CreateSecurityGroup"
+                "ec2:RevokeSecurityGroupIngress"
             ],
             "Resource": "*"
         },
@@ -21,35 +29,26 @@
             "Effect": "Allow",
             "Action": [
                 "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
-                "elasticloadbalancing:AttachLoadBalancerToSubnets",
-                "elasticloadbalancing:ConfigureHealthCheck",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",
-                "elasticloadbalancing:CreateLoadBalancerListeners",
                 "elasticloadbalancing:CreateRule",
                 "elasticloadbalancing:CreateTargetGroup",
                 "elasticloadbalancing:DeleteListener",
                 "elasticloadbalancing:DeleteLoadBalancer",
-                "elasticloadbalancing:DeleteLoadBalancerListeners",
                 "elasticloadbalancing:DeleteRule",
                 "elasticloadbalancing:DeleteTargetGroup",
                 "elasticloadbalancing:DescribeListeners",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeRules",
                 "elasticloadbalancing:DescribeTags",
-                "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",
                 "elasticloadbalancing:ModifyListener",
                 "elasticloadbalancing:ModifyLoadBalancerAttributes",
                 "elasticloadbalancing:ModifyRule",
                 "elasticloadbalancing:ModifyTargetGroup",
-                "elasticloadbalancing:ModifyTargetGroupAttributes",
                 "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
                 "elasticloadbalancing:RemoveTags",
-                "elasticloadbalancing:SetLoadBalancerListenerSSLCertificate",
                 "elasticloadbalancing:SetSecurityGroups",
                 "elasticloadbalancing:SetSubnets"
             ],
@@ -58,8 +57,8 @@
         {
             "Effect": "Allow",
             "Action": [
-                "acm:DescribeCertificate",
-                "acm:ListCertificates"
+                "iam:GetServerCertificate",
+                "iam:ListServerCertificates"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
* alpha sort
* remove extraneous actions for `elasticloadbalancing` per recursive grep of project (not just `pkg/aws`, derp)
* add missing `iam` actions