### PR TITLE
Burning the release/git hash into the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,14 @@
 all: container
 
 TAG?=1.0-alpha.7
+BUILD=$(shell git log --pretty=format:'%h' -n 1)
 PREFIX?=quay.io/coreos/alb-ingress-controller
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
+LDFLAGS=-X github.com/coreos/alb-ingress-controller/pkg/controller.build=git-$(BUILD) -X github.com/coreos/alb-ingress-controller/pkg/controller.release=$(TAG)
 
 server: cmd/main.go pkg/*/*.go pkg/*/*/*.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GOARM=6 go build -a -installsuffix cgo -ldflags '-w' -o server cmd/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GOARM=6 go build -a -installsuffix cgo -ldflags '-w $(LDFLAGS)' -o server cmd/main.go
 
 container: server
 	docker build --pull -t $(PREFIX):$(TAG) .

--- a/pkg/controller/alb-controller.go
+++ b/pkg/controller/alb-controller.go
@@ -49,6 +49,9 @@ type ALBController struct {
 
 var logger *log.Logger
 
+var release = "1.0.0"
+var build = "git-00000000"
+
 func init() {
 	logger = log.New("controller")
 }
@@ -230,8 +233,8 @@ func (ac *ALBController) DefaultIngressClass() string {
 func (ac *ALBController) Info() *ingress.BackendInfo {
 	return &ingress.BackendInfo{
 		Name:       "ALB Ingress Controller",
-		Release:    "1.0.0",
-		Build:      "git-00000000",
+		Release:    release,
+		Build:      build,
 		Repository: "git://github.com/coreos/alb-ingress-controller",
 	}
 }


### PR DESCRIPTION
This will leave some useful information in the logs

```
I1117 10:26:16.709600   44258 launch.go:112] &{ALB Ingress Controller 1.0-alpha.7 git-0ddcba1f git://github.com/coreos/alb-ingress-controller}
```