### PR TITLE
explicit target deregistration

### DIFF
--- a/pkg/alb/targetgroup/targetgroup.go
+++ b/pkg/alb/targetgroup/targetgroup.go
@@ -330,7 +330,7 @@ func (tg *TargetGroup) needsModification() bool {
 	return false
 }
 
-// Registers Targets (ec2 instances) to the Current, must be called when Current != Desired
+// Registers Targets (ec2 instances) to TargetGroup, must be called when Current != Desired
 func (tg *TargetGroup) registerTargets(additions util.AWSStringSlice, rOpts *ReconcileOptions) error {
 	targets := []*elbv2.TargetDescription{}
 	for _, target := range additions {
@@ -353,7 +353,7 @@ func (tg *TargetGroup) registerTargets(additions util.AWSStringSlice, rOpts *Rec
 
 	// when managing security groups, ensure sg is associated with instance
 	if rOpts.ManagedSGInstance != nil {
-		err := ec2.EC2svc.AssociateSGToInstanceIfNeeded(tg.Targets.Desired, rOpts.ManagedSGInstance)
+		err := ec2.EC2svc.AssociateSGToInstanceIfNeeded(additions, rOpts.ManagedSGInstance)
 		if err != nil {
 			return err
 		}
@@ -362,7 +362,7 @@ func (tg *TargetGroup) registerTargets(additions util.AWSStringSlice, rOpts *Rec
 	return nil
 }
 
-// Deregisters Targets (ec2 instances) to the Current, must be called when Current != Desired
+// Deregisters Targets (ec2 instances) from the TargetGroup, must be called when Current != Desired
 func (tg *TargetGroup) deregisterTargets(removals util.AWSStringSlice, rOpts *ReconcileOptions) error {
 	targets := []*elbv2.TargetDescription{}
 	for _, target := range removals {
@@ -383,9 +383,9 @@ func (tg *TargetGroup) deregisterTargets(removals util.AWSStringSlice, rOpts *Re
 
 	tg.Targets.Current = tg.Targets.Desired
 
-	// when managing security groups, ensure sg is associated with instance
+	// when managing security groups, ensure sg is disassociated with instance
 	if rOpts.ManagedSGInstance != nil {
-		err := ec2.EC2svc.AssociateSGToInstanceIfNeeded(tg.Targets.Desired, rOpts.ManagedSGInstance)
+		err := ec2.EC2svc.DisassociateSGFromInstanceIfNeeded(removals, rOpts.ManagedSGInstance)
 		if err != nil {
 			return err
 		}

--- a/pkg/aws/elbv2/elbv2.go
+++ b/pkg/aws/elbv2/elbv2.go
@@ -174,7 +174,15 @@ func (e *ELBV2) DescribeTargetGroupTargetsForArn(arn *string) (util.AWSStringSli
 		return nil, err
 	}
 	for _, targetHealthDescription := range targetGroupHealth.TargetHealthDescriptions {
-		targets = append(targets, targetHealthDescription.Target.Id)
+		if targetHealthDescription.TargetHealth.Reason != nil {
+			switch aws.StringValue(targetHealthDescription.TargetHealth.Reason) {
+			case elbv2.TargetHealthReasonEnumTargetDeregistrationInProgress:
+				// We don't need to count this instance in service if it is
+				// on its way out
+			default:
+				targets = append(targets, targetHealthDescription.Target.Id)
+			}
+		}
 	}
 	sort.Sort(targets)
 	return targets, err

--- a/pkg/util/types/types.go
+++ b/pkg/util/types/types.go
@@ -131,3 +131,16 @@ func (s Subnets) String() string {
 	}
 	return out
 }
+
+func Difference(a, b AWSStringSlice) (ab AWSStringSlice) {
+	mb := map[string]bool{}
+	for _, x := range b {
+		mb[*x] = true
+	}
+	for _, x := range a {
+		if _, ok := mb[*x]; !ok {
+			ab = append(ab, x)
+		}
+	}
+	return
+}


### PR DESCRIPTION
Borrowing some of the logic from the recent [NLB support](https://github.com/kubernetes/kubernetes/commit/63d4b85bf4f2894e65610a5446050a8844ca78cd) added to kubernetes, namely:

* exclusion of targets already marked for deregistration
* explicit deregistration