### PR TITLE
exception handling for current idle timeout attribute

### DIFF
--- a/pkg/albingress/albingress.go
+++ b/pkg/albingress/albingress.go
@@ -87,7 +87,7 @@ type NewALBIngressFromIngressOptions struct {
 	GetServiceNodePort    func(string, int32) (*int64, error)
 	GetNodes              func() util.AWSStringSlice
 	Recorder              record.EventRecorder
-	ConnectionIdleTimeout int64
+	ConnectionIdleTimeout *int64
 }
 
 // NewALBIngressFromIngress builds ALBIngress's based off of an Ingress object
@@ -198,7 +198,7 @@ type NewALBIngressFromAWSLoadBalancerOptions struct {
 	ManagedSG             *string
 	ManagedSGPorts        []int64
 	ManagedInstanceSG     *string
-	ConnectionIdleTimeout int64
+	ConnectionIdleTimeout *int64
 }
 
 // NewALBIngressFromAWSLoadBalancer builds ALBIngress's based off of an elbv2.LoadBalancer


### PR DESCRIPTION
With this snippet I was able to demonstrate that since the error isn't handled [here](https://github.com/coreos/alb-ingress-controller/blob/03cf52c2c7c0d21cf9685cc29aebec2bc02fb550/pkg/albingresses/albingresses.go#L134-L138), the value returned for idleTimeout is occasionally the default `0`, thus triggering needless load balancer attribute modifications:

```go
package main

import (
	"fmt"
	"strconv"

	"github.com/aws/aws-sdk-go/aws"
	"github.com/aws/aws-sdk-go/aws/session"
	"github.com/aws/aws-sdk-go/service/elbv2"
)

const (
	IdleTimeoutKey = "idle_timeout.timeout_seconds"
)

func main() {
	sess := session.Must(session.NewSession())
	svc := elbv2.New(sess)

	arn := aws.String("arn:aws:elasticloadbalancing:us-east-1:234212695392:loadbalancer/app/nonprod1-prd115-controller-17d6/1bca811ec6ea7137")

	idleTimeout := int64(0)
	in := &elbv2.DescribeLoadBalancerAttributesInput{
		LoadBalancerArn: arn,
	}
	attrs, err := svc.DescribeLoadBalancerAttributes(in)
	if err != nil {
		fmt.Printf("%v\n", err.Error())
	}
	for _, attr := range attrs.Attributes {
		if *attr.Key == IdleTimeoutKey {
			idleTimeout, err = strconv.ParseInt(*attr.Value, 10, 64)
			if err != nil {
				fmt.Printf("Failed to retrieve invalid idle timeout from ALB in AWS. Was: %s\n", *attr.Value)
			}
		}
	}
	fmt.Println(idleTimeout)
}
```

```shell
root@kube2iam-test:/go# go run main.go
60
root@kube2iam-test:/go# go run main.go
Throttling: Rate exceeded
	status code: 400, request id: 5aaf3885-d9ff-11e7-a559-2bffe66fa458
0
root@kube2iam-test:/go# go run main.go
60
```

This PR initializes the timeout to nil, and only performs the modification if not nil.