### PR TITLE
exclude draining and unused targets from current and desired groups

### DIFF
--- a/pkg/aws/elbv2/elbv2.go
+++ b/pkg/aws/elbv2/elbv2.go
@@ -34,7 +34,7 @@ type ELBV2API interface {
 	UpdateTags(arn *string, old util.Tags, new util.Tags) error
 	RemoveTargetGroup(in elbv2.DeleteTargetGroupInput) error
 	DescribeTagsForArn(arn *string) (util.Tags, error)
-	DescribeTargetGroupTargetsForArn(arn *string) (util.AWSStringSlice, error)
+	DescribeTargetGroupTargetsForArn(arn *string, targets []*elbv2.TargetDescription) (util.AWSStringSlice, error)
 	RemoveListener(in elbv2.DeleteListenerInput) error
 	DescribeTargetGroupsForLoadBalancer(loadBalancerArn *string) ([]*elbv2.TargetGroup, error)
 	DescribeListenersForLoadBalancer(loadBalancerArn *string) ([]*elbv2.Listener, error)
@@ -165,21 +165,26 @@ func (e *ELBV2) DescribeTagsForArn(arn *string) (util.Tags, error) {
 }
 
 // DescribeTargetGroupTargetsForArn looks up target group targets by an ARN.
-func (e *ELBV2) DescribeTargetGroupTargetsForArn(arn *string) (util.AWSStringSlice, error) {
-	var targets util.AWSStringSlice
-	targetGroupHealth, err := e.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
+func (e *ELBV2) DescribeTargetGroupTargetsForArn(arn *string, targets []*elbv2.TargetDescription) (result util.AWSStringSlice, err error) {
+	targetHealth, err := e.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
 		TargetGroupArn: arn,
+		Targets:        targets,
 	})
 	if err != nil {
-		return nil, err
+		return
 	}
-	for _, targetHealthDescription := range targetGroupHealth.TargetHealthDescriptions {
-		if targetHealthDescription.TargetHealth.Reason == nil {
-			targets = append(targets, targetHealthDescription.Target.Id)
+	for _, targetHealthDescription := range targetHealth.TargetHealthDescriptions {
+		switch aws.StringValue(targetHealthDescription.TargetHealth.State) {
+		case elbv2.TargetHealthStateEnumDraining:
+			// We don't need to count this instance
+		case elbv2.TargetHealthStateEnumUnused:
+			// We don't need to count this instance
+		default:
+			result = append(result, targetHealthDescription.Target.Id)
 		}
 	}
-	sort.Sort(targets)
-	return targets, err
+	sort.Sort(result)
+	return
 }
 
 // SetIdleTimeout attempts to update an ELBV2's connection idle timeout setting. It must


### PR DESCRIPTION
Including draining targets in the list of desired targets for a target group causes deregistered targets to be reregistered, which may adversely affect traffic destined to the load balancer if it is directed to an instance that's about to be terminated.