### PR TITLE
fix logic to retry target group deletion

### DIFF
--- a/pkg/aws/elbv2/elbv2.go
+++ b/pkg/aws/elbv2/elbv2.go
@@ -75,19 +75,19 @@ func (e *ELBV2) RemoveListener(in elbv2.DeleteListenerInput) error {
 func (e *ELBV2) RemoveTargetGroup(in elbv2.DeleteTargetGroupInput) error {
 	for i := 0; i < deleteTargetGroupReattemptMax; i++ {
 		_, err := e.DeleteTargetGroup(&in)
-		if err != nil {
-			if aerr, ok := err.(awserr.Error); ok {
-				switch aerr.Code() {
-				case elbv2.ErrCodeResourceInUseException:
-					time.Sleep(time.Duration(deleteTargetGroupReattemptSleep) * time.Second)
-				default:
-					return aerr
-				}
-			} else {
+		if err == nil {
+			break
+		}
+
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case elbv2.ErrCodeResourceInUseException:
+				time.Sleep(time.Duration(deleteTargetGroupReattemptSleep) * time.Second)
+			default:
 				return aerr
 			}
 		} else {
-			break
+			return aerr
 		}
 	}
 

--- a/pkg/aws/elbv2/elbv2.go
+++ b/pkg/aws/elbv2/elbv2.go
@@ -75,12 +75,19 @@ func (e *ELBV2) RemoveListener(in elbv2.DeleteListenerInput) error {
 func (e *ELBV2) RemoveTargetGroup(in elbv2.DeleteTargetGroupInput) error {
 	for i := 0; i < deleteTargetGroupReattemptMax; i++ {
 		_, err := e.DeleteTargetGroup(&in)
-		switch {
-		case err != nil && err.(awserr.Error).Code() == elbv2.ErrCodeResourceInUseException:
-			time.Sleep(time.Duration(deleteTargetGroupReattemptSleep) * time.Second)
-			continue
-		case err != nil:
-			return err
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				switch aerr.Code() {
+				case elbv2.ErrCodeResourceInUseException:
+					time.Sleep(time.Duration(deleteTargetGroupReattemptSleep) * time.Second)
+				default:
+					return aerr
+				}
+			} else {
+				return aerr
+			}
+		} else {
+			break
 		}
 	}
 


### PR DESCRIPTION
The `DeleteTargetGroup` event was observed in `CloudTrail` in rapid succession without a sleep interval. The reason was that because the case where `err == nil` wasn't handled. This is intended to rectify that behavior.