### PR TITLE
Always use local (to cluster) VPC ID for ALBs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 
 all: container
 
-TAG?=1.0-alpha.7
+TAG?=1.0-alpha.8
 BUILD=$(shell git log --pretty=format:'%h' -n 1)
 PREFIX?=quay.io/coreos/alb-ingress-controller
 ARCH?=amd64

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,6 +22,7 @@ import:
   - aws/request
   - aws/session
   - service/ec2
+  - service/ec2metadata
   - service/ec2/ec2iface
   - service/elbv2
   - service/elbv2/elbv2iface

--- a/pkg/alb/loadbalancer/loadbalancer.go
+++ b/pkg/alb/loadbalancer/loadbalancer.go
@@ -268,7 +268,7 @@ func (lb *LoadBalancer) reconcileExistingManagedSG() error {
 	if len(lb.DesiredPorts) < 1 {
 		return fmt.Errorf("No ports specified on ingress. Ingress resource may be misconfigured")
 	}
-	vpcID, err := ec2.EC2svc.GetVPCID(util.AvailabilityZones(lb.Desired.AvailabilityZones).AsSubnets())
+	vpcID, err := ec2.EC2svc.GetVPCID()
 	if err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func (lb *LoadBalancer) create(rOpts *ReconcileOptions) error {
 		sgs = append(sgs, lb.DesiredManagedSG)
 
 		if lb.DesiredManagedInstanceSG == nil {
-			vpcID, err := ec2.EC2svc.GetVPCID(util.AvailabilityZones(lb.Desired.AvailabilityZones).AsSubnets())
+			vpcID, err := ec2.EC2svc.GetVPCID()
 			if err != nil {
 				return err
 			}
@@ -313,7 +313,7 @@ func (lb *LoadBalancer) create(rOpts *ReconcileOptions) error {
 
 	// when sgs are not known, attempt to create them
 	if len(sgs) < 1 {
-		vpcID, err := ec2.EC2svc.GetVPCID(util.AvailabilityZones(lb.Desired.AvailabilityZones).AsSubnets())
+		vpcID, err := ec2.EC2svc.GetVPCID()
 		if err != nil {
 			return err
 		}

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -323,10 +323,22 @@ func (a *Annotations) setSecurityGroups(annotations map[string]string) error {
 	}
 
 	if len(names) > 0 {
-		in := &ec2.DescribeSecurityGroupsInput{Filters: []*ec2.Filter{{
-			Name:   aws.String("tag:Name"),
-			Values: names,
-		}}}
+		var vpcIds []*string
+		vpcId, err := albec2.EC2svc.GetVPCID()
+		if err != nil {
+			return err
+		}
+		vpcIds = append(vpcIds, vpcId)
+		in := &ec2.DescribeSecurityGroupsInput{Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:Name"),
+				Values: names,
+			},
+			{
+				Name:   aws.String("vpc-id"),
+				Values: vpcIds,
+			},
+		}}
 
 		describeSecurityGroupsOutput, err := albec2.EC2svc.DescribeSecurityGroups(in)
 		if err != nil {
@@ -437,10 +449,22 @@ func (a *Annotations) setSubnets(annotations map[string]string, clusterName stri
 	}
 
 	if len(names) > 0 {
-		in := &ec2.DescribeSubnetsInput{Filters: []*ec2.Filter{{
-			Name:   aws.String("tag:Name"),
-			Values: names,
-		}}}
+		var vpcIds []*string
+		vpcId, err := albec2.EC2svc.GetVPCID()
+		if err != nil {
+			return err
+		}
+		vpcIds = append(vpcIds, vpcId)
+		in := &ec2.DescribeSubnetsInput{Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:Name"),
+				Values: names,
+			},
+			{
+				Name:   aws.String("vpc-id"),
+				Values: vpcIds,
+			},
+		}}
 
 		describeSubnetsOutput, err := albec2.EC2svc.DescribeSubnets(in)
 		if err != nil {

--- a/pkg/annotations/validation.go
+++ b/pkg/annotations/validation.go
@@ -13,7 +13,7 @@ import (
 // resolveVPC attempt to resolve a VPC based on the provided subnets. This also acts as a way to
 // validate provided subnets exist.
 func (a *Annotations) resolveVPCValidateSubnets() error {
-	VPCID, err := albec2.EC2svc.GetVPCID(a.Subnets)
+	VPCID, err := albec2.EC2svc.GetVPCID()
 	if err != nil {
 		return fmt.Errorf("subnets %s were invalid, could not resolve to a VPC", a.Subnets)
 	}

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -23,10 +24,20 @@ const (
 // EC2svc is a pointer to the awsutil EC2 service
 var EC2svc *EC2
 
+// EC2Metadatasvc is a pointer to the awsutil EC2metadata service
+var EC2Metadatasvc *EC2MData
+
 // EC2 is our extension to AWS's ec2.EC2
 type EC2 struct {
 	ec2iface.EC2API
 	cache *ccache.Cache
+}
+
+// EC2MData is our extension to AWS's ec2metadata.EC2Metadata
+// cache is not required for this struct as we only use it to lookup
+// instance metadata when the cache for the EC2 struct is expired.
+type EC2MData struct {
+	*ec2metadata.EC2Metadata
 }
 
 // NewEC2 returns an awsutil EC2 service
@@ -34,6 +45,13 @@ func NewEC2(awsSession *session.Session) {
 	EC2svc = &EC2{
 		ec2.New(awsSession),
 		ccache.New(ccache.Configure()),
+	}
+}
+
+// NewEC2Metadata returns an awsutil EC2Metadata service
+func NewEC2Metadata(awsSession *session.Session) {
+	EC2Metadatasvc = &EC2MData{
+		ec2metadata.New(awsSession),
 	}
 }
 
@@ -473,39 +491,75 @@ func (e *EC2) CreateNewInstanceSG(sgName *string, sgID *string, vpcID *string) (
 	return oInstanceSG.GroupId, nil
 }
 
-// GetVPCID retrieves the VPC that the subnets passed are contained in.
-func (e *EC2) GetVPCID(subnets []*string) (*string, error) {
+// GetVPCID returns the VPC of the instance the controller is currently running on.
+// This is achieved by getting the identity document of the EC2 instance and using
+// the DescribeInstances call to determine its VPC ID.
+func (e *EC2) GetVPCID() (*string, error) {
 	var vpc *string
 
-	if len(subnets) == 0 {
-		return nil, fmt.Errorf("Empty subnet list provided to getVPCID")
-	}
-
-	key := fmt.Sprintf("%s-vpc", *subnets[0])
+	// If previously looked up (and not expired) the VpcId will be stored in the cache under the
+	// key 'vpc'.
+	key := "vpc"
 	item := e.cache.Get(key)
 
-	if item == nil {
-		subnetInfo, err := e.DescribeSubnets(&ec2.DescribeSubnetsInput{
-			SubnetIds: subnets,
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		if len(subnetInfo.Subnets) == 0 {
-			return nil, fmt.Errorf("DescribeSubnets returned no subnets")
-		}
-
-		vpc = subnetInfo.Subnets[0].VpcId
-		e.cache.Set(key, vpc, time.Minute*60)
-
-		albprom.AWSCache.With(prometheus.Labels{"cache": "vpc", "action": "miss"}).Add(float64(1))
-	} else {
+	// cache hit: return (pointer of) VpcId value
+	if item != nil {
 		vpc = item.Value().(*string)
 		albprom.AWSCache.With(prometheus.Labels{"cache": "vpc", "action": "hit"}).Add(float64(1))
+		return vpc, nil
 	}
 
+	// cache miss: begin lookup of VpcId based on current EC2 instance
+	// retrieve identity of current running instance
+	identityDoc, err := EC2Metadatasvc.GetInstanceIdentityDocument()
+	if err != nil {
+		return nil, err
+	}
+
+	// capture instance ID for lookup in DescribeInstances
+	// don't bother caching this value as it should never be re-retrieved unless
+	// the cache for the VpcId (looked up below) expires.
+	descInstancesInput := &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{aws.String(identityDoc.InstanceID)},
+	}
+
+	// capture description of this instance for later capture of VpcId
+	descInstancesOutput, err := e.DescribeInstances(descInstancesInput)
+	if err != nil {
+		return nil, err
+	}
+
+	// Before attempting to return VpcId of instance, ensure at least 1 reservation and instance
+	// (in that reservation) was found.
+	if err = instanceVPCIsValid(descInstancesOutput); err != nil {
+		return nil, err
+	}
+
+	vpc = descInstancesOutput.Reservations[0].Instances[0].VpcId
+	// cache the retrieved VpcId for next call
+	e.cache.Set(key, vpc, time.Minute*60)
+	albprom.AWSCache.With(prometheus.Labels{"cache": "vpc", "action": "miss"}).Add(float64(1))
 	return vpc, nil
+}
+
+// instanceVPCIsValid ensures returned instance data has a valid VPC ID in the output
+func instanceVPCIsValid(o *ec2.DescribeInstancesOutput) error {
+	if len(o.Reservations) < 1 {
+		return fmt.Errorf("When looking up VPC ID could not identify instance. Found %d reservations"+
+			" in AWS call. Should have found atleast 1.", len(o.Reservations))
+	}
+	if len(o.Reservations[0].Instances) < 1 {
+		return fmt.Errorf("When looking up VPC ID could not identify instance. Found %d instances"+
+			" in AWS call. Should have found atleast 1.", len(o.Reservations))
+	}
+	if o.Reservations[0].Instances[0].VpcId == nil {
+		return fmt.Errorf("When looking up VPC ID could not instance returned had a nil value for VPC.")
+	}
+	if *o.Reservations[0].Instances[0].VpcId == "" {
+		return fmt.Errorf("When looking up VPC ID could not instance returned had an empty value for VPC.")
+	}
+
+	return nil
 }
 
 // Status validates EC2 connectivity

--- a/pkg/controller/alb-controller.go
+++ b/pkg/controller/alb-controller.go
@@ -62,6 +62,7 @@ func NewALBController(awsconfig *aws.Config, conf *config.Config) *ALBController
 	sess := session.NewSession(awsconfig, conf.AWSDebug)
 	elbv2.NewELBV2(sess)
 	ec2.NewEC2(sess)
+	ec2.NewEC2Metadata(sess)
 	acm.NewACM(sess)
 	iam.NewIAM(sess)
 


### PR DESCRIPTION
Previously the VPC ID, and thus VPC ALBs would be created within, was
detected by looking up the VPC based on the subnets the controller
intended to use. This approach can create conflicts when the subnets are
looked up by name (or perhaps other tags). This can cause another VPC
with identical subnet names to be resolved.

This new approach resolves the VPC ID based on the current EC2 instance
the alb-ingress-controller is running on.