### PR TITLE
Remove livenessProbe

### DIFF
--- a/alb-ingress-controller-helm/Chart.yaml
+++ b/alb-ingress-controller-helm/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 name: alb-ingress-controller-helm
 sources:
   - https://github.com/coreos/alb-ingress-controller
-version: 0.0.9
+version: 0.0.10

--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -55,13 +55,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 30
-            periodSeconds: 60
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -70,7 +63,8 @@ spec:
               path: /healthz
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
+            periodSeconds: {{ .Values.controller.readinessProbeInterval }}
         {{- if .Values.controller.resources }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -35,6 +35,9 @@ controller:
 
   podLabels: {}
 
+  # How often (in seconds) to check controller readiness
+  readinessProbeInterval: 10
+
   resources: {}
     # limits:
     #   cpu: 100m


### PR DESCRIPTION
The /healthz endpoint currently checks AWS connectivity. That indicates
to me that it should be used as a readinessProbe, not a livenessProbe,
as restarting the Pod may not resolve the underlying issue.

We're also allowing the readinessProbe interval to be adjusted so AWS
throttling can be diminished.