### PR TITLE
optionally restrict scheme type by namespace

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,3 +61,25 @@ spec:
 ```
 
 > Currently, you can set only 1 namespace to watch in this flag. See [this Kubernetes issue](https://github.com/kubernetes/contrib/issues/847) for more details.
+
+### Limiting External Namespaces
+
+Setting the `--restrict-scheme` boolean flag to `true` will enable the ALB controller to check Namespaces for the `alb.ingress.kubernetes.io/allow-external` annotation before provisioning ALBs with an internet-facing scheme. This can also be set in the environment variable `ALB_CONTROLLER_RESTRICT_SCHEME`. For example, if the following is attempted with a namespace that does not have the `alb.ingress.kubernetes.io/allow-external` annotation set to `true`, it will not be created:
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: external-app
+  namespace: external-app
+  annotations:
+    alb.ingress.kubernetes.io/port: "8080,9000"
+    alb.ingress.kubernetes.io/subnets: subnet-63bf6318,subnet-0b20aa62
+    alb.ingress.kubernetes.io/security-groups: sg-1f84f776
+    alb.ingress.kubernetes.io/scheme: "internet-facing"
+    kubernetes.io/ingress.class: "alb"
+spec:
+	...
+```
+
+Whereas it will succeed if the `external-app` namespace has the `alb.ingress.kubernetes.io/allow-external` set appropriately.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -58,7 +58,7 @@ In this example, you'll
 	$ kubectl apply -f alb-ingress-controller.yaml
 	```
 
-	> The manifest above with deploy the controller to the `kube-system` namespace. If you deploy it outside of `kube-system` and are using RBAC, you may need to adjust RBAC roles and bindings.
+	> The manifest above will deploy the controller to the `kube-system` namespace. If you deploy it outside of `kube-system` and are using RBAC, you may need to adjust RBAC roles and bindings.
 
 1. Verify the deployment was successful and the controller started.
 

--- a/pkg/alb/loadbalancer/loadbalancer.go
+++ b/pkg/alb/loadbalancer/loadbalancer.go
@@ -589,6 +589,11 @@ func (l *LoadBalancer) StripDesiredState() {
 	}
 }
 
+// Return true if the namespace allows external scheme
+func (l *LoadBalancer) AllowsExternal(namespace string) bool {
+	return util.NamespaceAllowsExternal(namespace)
+}
+
 type ReconcileOptions struct {
 	Eventf func(string, string, string, ...interface{})
 }

--- a/pkg/albingresses/albingresses.go
+++ b/pkg/albingresses/albingresses.go
@@ -32,6 +32,7 @@ func init() {
 type NewALBIngressesFromIngressesOptions struct {
 	Recorder            record.EventRecorder
 	ClusterName         string
+	RestrictScheme      bool
 	ALBNamePrefix       string
 	Ingresses           []interface{}
 	ALBIngresses        ALBIngresses
@@ -64,6 +65,7 @@ func NewALBIngressesFromIngresses(o *NewALBIngressesFromIngressesOptions) ALBIng
 			Ingress:            ingResource,
 			ExistingIngress:    existingIngress,
 			ClusterName:        o.ClusterName,
+			RestrictScheme:     o.RestrictScheme,
 			ALBNamePrefix:      o.ALBNamePrefix,
 			GetServiceNodePort: o.GetServiceNodePort,
 			GetNodes:           o.GetNodes,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,4 +7,5 @@ type Config struct {
 	ClusterName     string
 	AWSDebug        bool
 	ALBSyncInterval time.Duration
+	RestrictScheme  bool
 }

--- a/pkg/controller/alb-controller.go
+++ b/pkg/controller/alb-controller.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -40,6 +41,7 @@ type ALBController struct {
 	recorder        record.EventRecorder
 	ALBIngresses    albingresses.ALBIngresses
 	clusterName     string
+	restrictScheme  bool
 	albNamePrefix   string
 	IngressClass    string
 	lastUpdate      time.Time
@@ -151,6 +153,7 @@ func (ac *ALBController) update() {
 	newIngresses := albingresses.NewALBIngressesFromIngresses(&albingresses.NewALBIngressesFromIngressesOptions{
 		Recorder:            ac.recorder,
 		ClusterName:         ac.clusterName,
+		RestrictScheme:      ac.restrictScheme,
 		ALBNamePrefix:       ac.albNamePrefix,
 		Ingresses:           ac.storeLister.Ingress.List(),
 		ALBIngresses:        ac.ALBIngresses,
@@ -243,6 +246,9 @@ func (ac *ALBController) Info() *ingress.BackendInfo {
 // ConfigureFlags adds command line parameters to the ingress cmd.
 func (ac *ALBController) ConfigureFlags(pf *pflag.FlagSet) {
 	pf.StringVar(&ac.clusterName, "clusterName", os.Getenv("CLUSTER_NAME"), "Cluster Name (required)")
+
+	rs, _ := strconv.ParseBool(os.Getenv("ALB_CONTROLLER_RESTRICT_SCHEME"))
+	pf.BoolVar(&ac.restrictScheme, "restrict-scheme", rs, "Restrict the scheme to internal except for whitelisted namespaces (defaults to false)")
 
 	albSyncParam := os.Getenv("ALB_SYNC_INTERVAL")
 	if albSyncParam == "" {


### PR DESCRIPTION
This allows restricting the scheme to `internal`.  When enabled, the annotation `alb.ingress.kubernetes.io/allow-external` can be added to a namespace to permit `internet-facing` scheme on ingresses in that namespace.