### PR TITLE
Support ALB IpAddressType (IPv6) via a new annotation

### DIFF
--- a/examples/iam-policy.json
+++ b/examples/iam-policy.json
@@ -51,6 +51,7 @@
                 "elasticloadbalancing:ModifyTargetGroup",
                 "elasticloadbalancing:RegisterTargets",
                 "elasticloadbalancing:RemoveTags",
+                "elasticloadbalancing:SetIpAddressType",
                 "elasticloadbalancing:SetSecurityGroups",
                 "elasticloadbalancing:SetSubnets"
             ],

--- a/pkg/alb/loadbalancer/loadbalancer.go
+++ b/pkg/alb/loadbalancer/loadbalancer.go
@@ -53,6 +53,7 @@ const (
 	schemeModified
 	managedSecurityGroupsModified
 	connectionIdleTimeoutModified
+	ipAddressTypeModified
 )
 
 type NewDesiredLoadBalancerOptions struct {
@@ -85,6 +86,7 @@ func NewDesiredLoadBalancer(o *NewDesiredLoadBalancerOptions) *LoadBalancer {
 			AvailabilityZones: o.Annotations.Subnets.AsAvailabilityZones(),
 			LoadBalancerName:  aws.String(name),
 			Scheme:            o.Annotations.Scheme,
+			IpAddressType:     o.Annotations.IpAddressType,
 			SecurityGroups:    o.Annotations.SecurityGroups,
 			VpcId:             o.Annotations.VPCID,
 		},
@@ -330,6 +332,7 @@ func (lb *LoadBalancer) create(rOpts *ReconcileOptions) error {
 		Name:           lb.Desired.LoadBalancerName,
 		Subnets:        util.AvailabilityZones(lb.Desired.AvailabilityZones).AsSubnets(),
 		Scheme:         lb.Desired.Scheme,
+		IpAddressType:  lb.Desired.IpAddressType,
 		Tags:           lb.DesiredTags,
 		SecurityGroups: sgs,
 	}
@@ -415,6 +418,22 @@ func (lb *LoadBalancer) modify(rOpts *ReconcileOptions) error {
 			rOpts.Eventf(api.EventTypeNormal, "MODIFY", "%s subnets modified", *lb.Current.LoadBalancerName)
 			lb.logger.Infof("Completed subnets modification. Subnets are %s.",
 				log.Prettify(lb.Current.AvailabilityZones))
+		}
+
+		// Modify IP address type
+		if needsMod&ipAddressTypeModified != 0 {
+			lb.logger.Infof("Start IP address type modification.")
+			in := &elbv2.SetIpAddressTypeInput{
+				LoadBalancerArn: lb.Current.LoadBalancerArn,
+				IpAddressType:   lb.Desired.IpAddressType,
+			}
+			if _,err := albelbv2.ELBV2svc.SetIpAddressType(in); err != nil {
+				return fmt.Errorf("Failure Setting ALB IpAddressType: %s", err)
+			}
+			lb.Current.IpAddressType = lb.Desired.IpAddressType
+			rOpts.Eventf(api.EventTypeNormal, "MODIFY", "%s ip address type modified", *lb.Current.LoadBalancerName)
+			lb.logger.Infof("Completed IP address type modification. Type is %s.", *lb.Current.LoadBalancerName,
+				*lb.Current.IpAddressType)
 		}
 
 		// Modify Tags
@@ -536,6 +555,11 @@ func (lb *LoadBalancer) needsModification() (loadBalancerChange, bool) {
 	if !util.DeepEqual(lb.Current.Scheme, lb.Desired.Scheme) {
 		changes |= schemeModified
 		return changes, false
+	}
+
+	if !util.DeepEqual(lb.Current.IpAddressType, lb.Desired.IpAddressType) {
+		changes |= ipAddressTypeModified
+		return changes, true
 	}
 
 	currentSubnets := util.AvailabilityZones(lb.Current.AvailabilityZones).AsSubnets()

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -40,6 +40,36 @@ func TestSetScheme(t *testing.T) {
 	}
 }
 
+func TestSetIpAddressType(t *testing.T) {
+	var tests = []struct {
+		ipAddressType string
+		expected string
+		pass   bool
+	}{
+		{"", "ipv4", true}, // ip-address-type has a sane default
+		{"/", "", false},
+		{"ipv4", "ipv4",true},
+		{"ipv4", "dualstack",false},
+		{"dualstack", "ipv4", false},
+		{"dualstack", "dualstack", true},
+	}
+
+	for _, tt := range tests {
+		a := &Annotations{}
+
+		err := a.setIpAddressType(map[string]string{ipAddressTypeKey: tt.ipAddressType})
+		if err != nil && tt.pass {
+			t.Errorf("setIpAddressType(%v): expected %v, actual %v", tt.ipAddressType, tt.pass, err)
+		}
+		if err == nil && tt.pass && tt.expected != *a.IpAddressType {
+			t.Errorf("setIpAddressType(%v): expected %v, actual %v", tt.ipAddressType, tt.expected, *a.IpAddressType)
+		}
+		if err == nil && !tt.pass && tt.expected == *a.IpAddressType {
+			t.Errorf("setIpAddressType(%v): expected %v, actual %v", tt.ipAddressType, tt.expected, *a.IpAddressType)
+		}
+	}
+}
+
 // Should fail to create due to healthchecktimeout being greater than HealthcheckIntervalSeconds
 func TestHealthcheckSecondsValidation(t *testing.T) {
 	a := &Annotations{}


### PR DESCRIPTION
This is a slight rewrite of @danopia request from #154

```ipv4``` is AWS’s default value, and this annotation allows upgrading to
```dualstack``` or sticking with no value (aka ```ipv4```)

- Annotation key: ```alb.ingress.kubernetes.io/ip-address-type```
- Default value: ```ipv4``` (as per AWS)
- Possible other value: ```dualstack```
- ALBs can be modified without recreation

Please note that you have to add IPv6 prefixes to your VPC and the subnets holding your ALBs before dualstack will work.