### PR TITLE
allow disabling the liveness probe

### DIFF
--- a/alb-ingress-controller-helm/Chart.yaml
+++ b/alb-ingress-controller-helm/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 name: alb-ingress-controller-helm
 sources:
   - https://github.com/coreos/alb-ingress-controller
-version: 0.0.10
+version: 0.0.11

--- a/alb-ingress-controller-helm/templates/controller-deployment.yaml
+++ b/alb-ingress-controller-helm/templates/controller-deployment.yaml
@@ -65,6 +65,15 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: {{ .Values.controller.readinessProbeInterval }}
+{{ if .Values.controller.livenessProbeEnabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: {{ .Values.controller.livenessProbeInterval }}
+{{- end }}
         {{- if .Values.controller.resources }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}

--- a/alb-ingress-controller-helm/values.yaml
+++ b/alb-ingress-controller-helm/values.yaml
@@ -38,6 +38,11 @@ controller:
 
   # How often (in seconds) to check controller readiness
   readinessProbeInterval: 10
+  # Whether to enable the liveness probe
+  livenessProbeEnabled: true
+  # How often (in seconds) to check controller liveness
+  livenessProbeInterval: 60
+
 
   resources: {}
     # limits:


### PR DESCRIPTION
During periods of AWS API throttling, the liveness probe can lead to a crash loop in the controller. This makes the liveness probe configurable, so it can be disabled to prevent the crash loop from happening.