### PR TITLE
fix fqdn length bug

### DIFF
--- a/pkg/alb/rules/rules.go
+++ b/pkg/alb/rules/rules.go
@@ -107,10 +107,10 @@ func (rs Rules) FindUnusedTGs(tgs targetgroups.TargetGroups) targetgroups.Target
 	for _, tg := range tgs {
 		used := false
 		for _, r := range rs {
-			if r.Current.Actions[0].TargetGroupArn == nil {
+			if r.Current != nil && r.Current.Actions[0] != nil && r.Current.Actions[0].TargetGroupArn == nil {
 				continue
 			}
-			if *r.Current.Actions[0].TargetGroupArn == *tg.Current.TargetGroupArn {
+			if r.Current != nil && r.Current.Actions[0] != nil && *r.Current.Actions[0].TargetGroupArn == *tg.Current.TargetGroupArn {
 				used = true
 				break
 			}


### PR DESCRIPTION
If the FQDN is exactly 253 characters it will cause a segfault:

```
E0226 22:03:48.967940       1 rule.go:172] [ALB-INGRESS] [prd354/webservice-chart-e2e-test-brian-webservice] [ERROR]: Failed Rule creation. Rule: {  Act
ions: [{      TargetGroupArn: "arn:aws:elasticloadbalancing:us-east-1:234212695392:targetgroup/sandbox3-30369-HTTP-85e7978/c8399964f12fe95d",      Type:
 "forward"    }],  Conditions: [{      Field: "host-header",      Values: ["<REDACTED>"]    },{      Field: "path-pattern",      Values: ["/"]    }],  IsDefault: false,  Priority: "1"} | Error: ValidationError: Co
ndition value for 'host-header' cannot contain more than 128 characters                                                
E0226 22:03:48.967960       1 rule.go:172] [ALB-INGRESS] [prd354/webservice-chart-e2e-test-brian-webservice] [ERROR]:   status code: 400, request id: ec
395fde-1b40-11e8-bc57-9152037a8f7f                                                                                                                      
panic: runtime error: invalid memory address or nil pointer dereference                                                                                 
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x147b680]                                                                                 
                                                                                                                                                        
goroutine 1043 [running]:                                                                                                                    
github.com/coreos/alb-ingress-controller/pkg/alb/rules.Rules.FindUnusedTGs(0xc42033b850, 0x2, 0x2, 0xc42084e048, 0x1, 0x1, 0x0, 0x1, 0xc420e3ff20)      
        /go/src/github.com/coreos/alb-ingress-controller/pkg/alb/rules/rules.go:113 +0x90                                                               
github.com/coreos/alb-ingress-controller/pkg/alb/loadbalancer.(*LoadBalancer).Reconcile(0xc420426ea0, 0xc420c71f60, 0xc420ffda90, 0x7fe0d2b8c6c8, 0x0)  
        /go/src/github.com/coreos/alb-ingress-controller/pkg/alb/loadbalancer/loadbalancer.go:260 +0x8bb                                                
github.com/coreos/alb-ingress-controller/pkg/albingress.(*ALBIngress).Reconcile(0xc420440840, 0xc4204617b8)                                             
        /go/src/github.com/coreos/alb-ingress-controller/pkg/albingress/albingress.go:321 +0xb4                           
github.com/coreos/alb-ingress-controller/pkg/controller.(*ALBController).update.func1(0xc420ffdfb0, 0xc420440840)                                       
        /go/src/github.com/coreos/alb-ingress-controller/pkg/controller/alb-controller.go:180 +0x9e                                                     
created by github.com/coreos/alb-ingress-controller/pkg/controller.(*ALBController).update                                                              
        /go/src/github.com/coreos/alb-ingress-controller/pkg/controller/alb-controller.go:178 +0x49b     
```

Afterwards we still get the error: 
```
E0226 22:03:48.967940       1 rule.go:172] [ALB-INGRESS] [prd354/webservice-chart-e2e-test-brian-webservice] [ERROR]: Failed Rule creation. Rule: {  Act
ions: [{      TargetGroupArn: "arn:aws:elasticloadbalancing:us-east-1:234212695392:targetgroup/sandbox3-30369-HTTP-85e7978/c8399964f12fe95d",      Type:
 "forward"    }],  Conditions: [{      Field: "host-header",      Values: ["<REDACTED>"]    },{      Field: "path-pattern",      Values: ["/"]    }],  IsDefault: false,  Priority: "1"} | Error: ValidationError: Co
ndition value for 'host-header' cannot contain more than 128 characters     
```

But it no longer throws a segfault.