### PR TITLE
Add Andrew Tandoc (AWS) as project maintainer.

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,3 @@
+Andrew Tandoc <tandoca@amazon.com> (@andrewtandoc) pkg:*
+Josh Rosso <joshrosso@gmail.com> (@joshrosso) pkg:*
 Kraig Amador <kraig.amador@ticketmaster.com> (@bigkraig) pkg:*
-Josh Rosso <josh.rosso@coreos.com> (@joshrosso) pkg:*


### PR DESCRIPTION
- Adds Andrew Tandoc as maintainer
- Alphabetizes MAINTAINERS
- Updates @joshrosso's github email

This PR requires someone with repository admin access to add Andrew.
 