### PR TITLE
Cleaned up some compiler warnings around string formatting

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -323,7 +323,7 @@ func (a *Annotations) setScheme(annotations map[string]string, ingressNamespace,
 		return fmt.Errorf("ALB Scheme [%v] must be either `internal` or `internet-facing`", annotations[schemeKey])
 	}
 	a.Scheme = aws.String(annotations[schemeKey])
-	cacheKey := fmt.Sprintf("scheme-%s-%s-%s-%s", config.RestrictScheme, config.RestrictSchemeNamespace, ingressNamespace, ingressName)
+	cacheKey := fmt.Sprintf("scheme-%v-%s-%s-%s", config.RestrictScheme, config.RestrictSchemeNamespace, ingressNamespace, ingressName)
 	if item := cacheLookup(cacheKey); item != nil {
 		return nil
 	}

--- a/pkg/controller/alb-controller_test.go
+++ b/pkg/controller/alb-controller_test.go
@@ -12,7 +12,7 @@ func TestALBNamePrefixGeneratedCompliesWithALB(t *testing.T) {
 	in := "cluster-name-hello"
 	actualName, err := cleanClusterName(in)
 	if err != nil {
-		t.Error("Error returned atttempted to create ALB prefix. Error: %s", err.Error())
+		t.Errorf("Error returned atttempted to create ALB prefix. Error: %s", err.Error())
 	}
 
 	if actualName != expectedName {


### PR DESCRIPTION
Cleaned up some compiler warnings thrown in some string formatting/building:

```
# github.com/coreos/alb-ingress-controller/pkg/annotations

pkg/annotations/annotations.go:326: Sprintf format %s has arg config.RestrictScheme of wrong type bool

# github.com/coreos/alb-ingress-controller/pkg/controller

pkg/controller/alb-controller_test.go:15: Error call has possible formatting directive %s
```