### PR TITLE
Add missing kube ingress.class annotation to examples [Small] #369

### DIFF
--- a/docs/ingress-resources.md
+++ b/docs/ingress-resources.md
@@ -15,6 +15,7 @@ metadata:
   name: "nginx-ingress"
   namespace: "2048-game"
   annotations:
+    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internal
     alb.ingress.kubernetes.io/subnets: subnet-1234
     alb.ingress.kubernetes.io/security-groups: sg-1234

--- a/examples/2048/2048-ingress.yaml
+++ b/examples/2048/2048-ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "nginx-ingress"
   namespace: "2048-game"
   annotations:
+    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internal
     alb.ingress.kubernetes.io/subnets: subnet-1234
     alb.ingress.kubernetes.io/security-groups: sg-1234

--- a/examples/echoservice/echoserver-ingress.yaml
+++ b/examples/echoservice/echoserver-ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   name: echoserver
   namespace: echoserver
   annotations:
+    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     #alb.ingress.kubernetes.io/subnets: subnet-1234
     #alb.ingress.kubernetes.io/security-groups: sg-1234


### PR DESCRIPTION
Add missing kube ingress.class annotation to example ingress.yamls and documentation to fix #369 