### PR TITLE
Fix build info injection [Small]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BUILD=$(shell git log --pretty=format:'%h' -n 1)
 PREFIX?=quay.io/coreos/alb-ingress-controller
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-LDFLAGS=-X github.com/coreos/alb-ingress-controller/pkg/controller.build=git-$(BUILD) -X github.com/coreos/alb-ingress-controller/pkg/controller.release=$(TAG)
+LDFLAGS=-X github.com/coreos/alb-ingress-controller/pkg/controller.Build=git-$(BUILD) -X github.com/coreos/alb-ingress-controller/pkg/controller.Release=$(TAG)
 
 server: cmd/main.go pkg/*/*.go pkg/*/*/*.go
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GOARM=6 go build -a -installsuffix cgo -ldflags '-w $(LDFLAGS)' -o server cmd/main.go

--- a/pkg/controller/alb-controller.go
+++ b/pkg/controller/alb-controller.go
@@ -52,8 +52,8 @@ type ALBController struct {
 
 var logger *log.Logger
 
-var release = "1.0.0"
-var build = "git-00000000"
+var Release = "1.0.0"
+var Build = "git-00000000"
 
 func init() {
 	logger = log.New("controller")
@@ -249,8 +249,8 @@ func (ac *ALBController) DefaultIngressClass() string {
 func (ac *ALBController) Info() *ingress.BackendInfo {
 	return &ingress.BackendInfo{
 		Name:       "ALB Ingress Controller",
-		Release:    release,
-		Build:      build,
+		Release:    Release,
+		Build:      Build,
 		Repository: "git://github.com/coreos/alb-ingress-controller",
 	}
 }


### PR DESCRIPTION
I noticed that 1.0-alpha.7 was printing the defaults for build info upon start up, so here's a tiny PR to fix that by switching global build and release vars from private to public.