### PR TITLE
Add ignore-host-header annotation

### DIFF
--- a/docs/ingress-resources.md
+++ b/docs/ingress-resources.md
@@ -66,6 +66,7 @@ alb.ingress.kubernetes.io/security-groups
 alb.ingress.kubernetes.io/subnets
 alb.ingress.kubernetes.io/successCodes
 alb.ingress.kubernetes.io/tags
+alb.ingress.kubernetes.io/ignore-host-header
 alb.ingress.kubernetes.io/ip-address-type
 ```
 
@@ -98,13 +99,15 @@ Optional annotations are:
 - **subnets**: The subnets where the ALB instance should be deployed. Must include 2 subnets, each in a different [availability zone](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html). These can be referenced by subnet IDs or the name tag associated with the subnet.  Example values for subnet IDs are `subnet-a4f0098e,subnet-457ed533,subnet-95c904cd`. Example values for name tags are: `webSubnet,appSubnet`. If subnets are not specified the ALB controller will attempt to detect qualified subnets. This qualification is done by locating subnets that match the following criteria.
 
   - kubernetes.io/cluster/$CLUSTER_NAME where $CLUSTER_NAME is the same cluster name specified on the ingress controller. The value of this tag must be 'shared'.
-    
+
   - kubernetes.io/role/alb-ingress the value of this tag should be empty.
-    
+
   - After subnets matching the above 2 tags have been located, they are checked to ensure 2 or more are in unique AZs, otherwise the ALB will not be created. If 2 subnets share the same AZ, only 1 of the 2 is used.
 
 - **successCodes**: Defines the HTTP status code that should be expected when doing health checks against the defined `healthcheck-path`. When omitted, `200` is used.
 
 - **tags**: Defines [AWS Tags](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) that should be applied to the ALB instance and Target groups.
+
+- **ignore-host-header**: Creates routing rules without [Host Header Checks](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#host-conditions).
 
 - **ip-address-type**: The IP address type thats used to either route IPv4 traffic only or to route both IPv4 and IPv6 traffic. Can be either `dualstack` or `ipv4`. When omitted `ipv4` is used.

--- a/pkg/alb/listeners/listeners.go
+++ b/pkg/alb/listeners/listeners.go
@@ -170,10 +170,11 @@ func NewDesiredListeners(o *NewDesiredListenersOptions) (Listeners, error) {
 			var err error
 
 			newListener.Rules, p, err = rules.NewDesiredRules(&rules.NewDesiredRulesOptions{
-				Priority:      p,
-				Logger:        o.Logger,
-				ListenerRules: newListener.Rules,
-				Rule:          &rule,
+				Priority:         p,
+				Logger:           o.Logger,
+				ListenerRules:    newListener.Rules,
+				Rule:             &rule,
+				IgnoreHostHeader: *o.Annotations.IgnoreHostHeader,
 			})
 			if err != nil {
 				return nil, err

--- a/pkg/alb/listeners/listeners_test.go
+++ b/pkg/alb/listeners/listeners_test.go
@@ -82,7 +82,8 @@ func TestNewSingleListener(t *testing.T) {
 	// mock ingress options
 	o := &NewDesiredListenersOptions{
 		Annotations: &annotations.Annotations{
-			Ports: []annotations.PortData{{ports[0], "HTTP"}},
+			Ports:            []annotations.PortData{{ports[0], "HTTP"}},
+			IgnoreHostHeader: aws.Bool(false),
 		},
 		Logger: logger,
 		Ingress: &extensions.Ingress{
@@ -125,6 +126,7 @@ func TestMultipleListeners(t *testing.T) {
 		if schemes[i] {
 			as.Scheme = aws.String("HTTPS")
 		}
+		as.IgnoreHostHeader = aws.Bool(false)
 
 		extRules := extensions.IngressRule{
 			Host: hosts[i],

--- a/pkg/alb/rule/rule.go
+++ b/pkg/alb/rule/rule.go
@@ -26,11 +26,12 @@ type Rule struct {
 }
 
 type NewDesiredRuleOptions struct {
-	Priority int
-	Hostname string
-	Path     string
-	SvcName  string
-	Logger   *log.Logger
+	Priority         int
+	Hostname         string
+	IgnoreHostHeader bool
+	Path             string
+	SvcName          string
+	Logger           *log.Logger
 }
 
 // NewDesiredRule returns an rule.Rule based on the provided parameters.
@@ -53,7 +54,7 @@ func NewDesiredRule(o *NewDesiredRuleOptions) *Rule {
 	}
 
 	if !*r.IsDefault {
-		if o.Hostname != "" {
+		if o.Hostname != "" && !o.IgnoreHostHeader {
 			r.Conditions = append(r.Conditions, &elbv2.RuleCondition{
 				Field:  aws.String("host-header"),
 				Values: []*string{aws.String(o.Hostname)},

--- a/pkg/alb/rules/rules.go
+++ b/pkg/alb/rules/rules.go
@@ -16,10 +16,11 @@ import (
 type Rules []*rule.Rule
 
 type NewDesiredRulesOptions struct {
-	Priority      int
-	Logger        *log.Logger
-	ListenerRules Rules
-	Rule          *extensions.IngressRule
+	Priority         int
+	Logger           *log.Logger
+	ListenerRules    Rules
+	Rule             *extensions.IngressRule
+	IgnoreHostHeader bool
 }
 
 // NewDesiredRules returns a Rules created by appending the IngressRule paths to a ListenerRules.
@@ -40,11 +41,12 @@ func NewDesiredRules(o *NewDesiredRulesOptions) (Rules, int, error) {
 
 	for _, path := range paths {
 		r := rule.NewDesiredRule(&rule.NewDesiredRuleOptions{
-			Priority: o.Priority,
-			Hostname: o.Rule.Host,
-			Path:     path.Path,
-			SvcName:  path.Backend.ServiceName,
-			Logger:   o.Logger,
+			Priority:         o.Priority,
+			Hostname:         o.Rule.Host,
+			IgnoreHostHeader: o.IgnoreHostHeader,
+			Path:             path.Path,
+			SvcName:          path.Backend.ServiceName,
+			Logger:           o.Logger,
 		})
 		if !rs.merge(r) {
 			rs = append(rs, r)

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -42,6 +42,7 @@ const (
 	subnetsKey                    = "alb.ingress.kubernetes.io/subnets"
 	successCodesKey               = "alb.ingress.kubernetes.io/successCodes"
 	tagsKey                       = "alb.ingress.kubernetes.io/tags"
+	ignoreHostHeader              = "alb.ingress.kubernetes.io/ignore-host-header"
 	clusterTagKey                 = "tag:kubernetes.io/cluster"
 	clusterTagValue               = "shared"
 	albRoleTagKey                 = "tag:kubernetes.io/role/alb-ingress"
@@ -69,6 +70,7 @@ type Annotations struct {
 	Subnets                    util.Subnets
 	SuccessCodes               *string
 	Tags                       []*elbv2.Tag
+	IgnoreHostHeader           *bool
 	VPCID                      *string
 	Attributes                 []*elbv2.LoadBalancerAttribute
 }
@@ -113,6 +115,7 @@ func ParseAnnotations(annotations map[string]string, clusterName string, ingress
 		a.setSubnets(annotations, clusterName),
 		a.setSuccessCodes(annotations),
 		a.setTags(annotations),
+		a.setIgnoreHostHeader(annotations),
 		a.setWafAclId(annotations),
 		a.setAttributes(annotations),
 	} {
@@ -608,6 +611,15 @@ func (a *Annotations) setTags(annotations map[string]string) error {
 
 	if len(badTags) > 0 {
 		return fmt.Errorf("Unable to parse `%s` into Key=Value pair(s)", strings.Join(badTags, ", "))
+	}
+	return nil
+}
+
+func (a *Annotations) setIgnoreHostHeader(annotations map[string]string) error {
+	if annotations[ignoreHostHeader] == "" {
+		a.IgnoreHostHeader = aws.Bool(false)
+	} else {
+		a.IgnoreHostHeader = aws.Bool(true)
 	}
 	return nil
 }

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -616,10 +616,10 @@ func (a *Annotations) setTags(annotations map[string]string) error {
 }
 
 func (a *Annotations) setIgnoreHostHeader(annotations map[string]string) error {
-	if annotations[ignoreHostHeader] == "" {
-		a.IgnoreHostHeader = aws.Bool(false)
+	if ihh, err := strconv.ParseBool(annotations[ignoreHostHeader]); err == nil {
+		a.IgnoreHostHeader = aws.Bool(ihh)
 	} else {
-		a.IgnoreHostHeader = aws.Bool(true)
+		a.IgnoreHostHeader = aws.Bool(false)
 	}
 	return nil
 }

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -76,6 +76,36 @@ func TestSetIpAddressType(t *testing.T) {
 	}
 }
 
+func TestSetIgnoreHostHeader(t *testing.T) {
+	var tests = []struct {
+		ignoreHostHeader string
+		expected         bool
+	}{
+		{"", false},
+		{"invalid_input", false},
+		{"0", false},
+		{"F", false},
+		{"f", false},
+		{"FALSE", false},
+		{"false", false},
+		{"False", false},
+		{"1", true},
+		{"T", true},
+		{"t", true},
+		{"TRUE", true},
+		{"true", true},
+		{"True", true},
+	}
+
+	for _, tt := range tests {
+		a := &Annotations{}
+
+		if a.setIgnoreHostHeader(map[string]string{ignoreHostHeader: tt.ignoreHostHeader}); *a.IgnoreHostHeader != tt.expected {
+			t.Errorf("setIgnoreHostHeader(%v): expected %v, actual %v", tt.ignoreHostHeader, tt.expected, *a.IgnoreHostHeader)
+		}
+	}
+}
+
 // Should fail to create due to healthchecktimeout being greater than HealthcheckIntervalSeconds
 func TestHealthcheckSecondsValidation(t *testing.T) {
 	a := &Annotations{}


### PR DESCRIPTION
When not empty the Host header check won't be enabled as part of the ALB listener routing rules.

This commit closes #371.