### PR TITLE
Refactored annotation/validation into interface

### DIFF
--- a/pkg/albingress/albingress.go
+++ b/pkg/albingress/albingress.go
@@ -94,7 +94,7 @@ type NewALBIngressFromIngressOptions struct {
 // https://godoc.org/k8s.io/kubernetes/pkg/apis/extensions#Ingress. Creates a new ingress object,
 // and looks up to see if a previous ingress object with the same id is known to the ALBController.
 // If there is an issue and the ingress is invalid, nil is returned.
-func NewALBIngressFromIngress(o *NewALBIngressFromIngressOptions) *ALBIngress {
+func NewALBIngressFromIngress(o *NewALBIngressFromIngressOptions, annotationFactory annotations.AnnotationFactory) *ALBIngress {
 	var err error
 
 	// Create newIngress ALBIngress object holding the resource details and some cluster information.
@@ -122,7 +122,7 @@ func NewALBIngressFromIngress(o *NewALBIngressFromIngressOptions) *ALBIngress {
 	}
 
 	// Load up the ingress with our current annotations.
-	newIngress.annotations, err = annotations.ParseAnnotations(o.Ingress.Annotations, o.ClusterName, o.Ingress.Namespace, o.Ingress.Name)
+	newIngress.annotations, err = annotationFactory.ParseAnnotations(o.Ingress)
 	if err != nil {
 		msg := fmt.Sprintf("Error parsing annotations: %s", err.Error())
 		newIngress.Reconciled = false

--- a/pkg/albingress/albingress_test.go
+++ b/pkg/albingress/albingress_test.go
@@ -1,5 +1,14 @@
 package albingress
 
+import (
+	"testing"
+	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/coreos/alb-ingress-controller/pkg/annotations"
+	"github.com/coreos/alb-ingress-controller/pkg/util/types"
+)
 var a *ALBIngress
 
 func setup() {
@@ -16,3 +25,59 @@ func setup() {
 	}
 
 }
+
+func TestNewALBIngressFromIngress(t *testing.T) {
+	options := &NewALBIngressFromIngressOptions{
+		Ingress: &extensions.Ingress{
+			Spec: extensions.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					v1beta1.IngressRule{
+						Host: "example.com",
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									v1beta1.HTTPIngressPath{
+										Path: "/",
+										Backend: v1beta1.IngressBackend{
+											ServicePort: intstr.FromInt(80),
+											ServiceName: "testService",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string {
+					"alb.ingress.kubernetes.io/subnets" : "subnet-1,subnet-2",
+					"alb.ingress.kubernetes.io/security-groups" : "sg-1",
+					"alb.ingress.kubernetes.io/scheme" : "internet-facing",
+				},
+				ClusterName: "testCluster",
+				Namespace: "test",
+				Name: "testIngress",
+			},
+		},
+		GetServiceNodePort: func(s string, i int32) (*int64, error) {
+			nodePort := int64(8000)
+			return &nodePort, nil
+		},
+		GetNodes: func() types.AWSStringSlice {
+			instance1 := "i-1"
+			instance2 := "i-2"
+			return types.AWSStringSlice{&instance1, &instance2}
+		},
+		ClusterName: "testCluster",
+		ALBNamePrefix: "albNamePrefix",
+	}
+	ingress := NewALBIngressFromIngress(
+		options,
+		annotations.NewValidatingAnnotationFactory(annotations.FakeValidator{VpcId: "vpc-1"}),
+	)
+	if ingress == nil {
+		t.Errorf("NewALBIngressFromIngress returned nil")
+	}
+}
+

--- a/pkg/albingresses/albingresses.go
+++ b/pkg/albingresses/albingresses.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coreos/alb-ingress-controller/pkg/aws/waf"
 	"github.com/coreos/alb-ingress-controller/pkg/util/log"
 	util "github.com/coreos/alb-ingress-controller/pkg/util/types"
+	"github.com/coreos/alb-ingress-controller/pkg/annotations"
 )
 
 // ALBIngresses is a list of ALBIngress. It is held by the ALBController instance and evaluated
@@ -44,7 +45,7 @@ type NewALBIngressesFromIngressesOptions struct {
 }
 
 // NewALBIngressesFromIngresses returns a ALBIngresses created from the Kubernetes ingress state.
-func NewALBIngressesFromIngresses(o *NewALBIngressesFromIngressesOptions) ALBIngresses {
+func NewALBIngressesFromIngresses(o *NewALBIngressesFromIngressesOptions, annotationFactory annotations.AnnotationFactory) ALBIngresses {
 	var ALBIngresses ALBIngresses
 
 	// Find every ingress currently in Kubernetes.
@@ -70,7 +71,7 @@ func NewALBIngressesFromIngresses(o *NewALBIngressesFromIngressesOptions) ALBIng
 			GetServiceNodePort: o.GetServiceNodePort,
 			GetNodes:           o.GetNodes,
 			Recorder:           o.Recorder,
-		})
+		}, annotationFactory)
 
 		// Add the new ALBIngress instance to the new ALBIngress list.
 		ALBIngresses = append(ALBIngresses, ALBIngress)

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -4,14 +4,20 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	extensions "k8s.io/api/extensions/v1beta1"
 )
 
 const clusterName = "testCluster"
 const ingressName = "testIngressName"
 const ingressNamespace = "test-namespace"
 
+func fakeValidator() FakeValidator {
+	return FakeValidator{VpcId:"vpc-1"}
+}
+
 func TestParseAnnotations(t *testing.T) {
-	_, err := ParseAnnotations(nil, clusterName, ingressName, ingressNamespace)
+	vf := NewValidatingAnnotationFactory(FakeValidator{VpcId:"vpc-1"})
+	_, err := vf.ParseAnnotations(&extensions.Ingress{})
 	if err == nil {
 		t.Fatalf("ParseAnnotations should not accept nil for annotations")
 	}
@@ -33,7 +39,7 @@ func TestSetScheme(t *testing.T) {
 	for _, tt := range tests {
 		a := &Annotations{}
 
-		err := a.setScheme(map[string]string{schemeKey: tt.scheme}, ingressName, ingressNamespace)
+		err := a.setScheme(map[string]string{schemeKey: tt.scheme}, ingressName, ingressNamespace, fakeValidator())
 		if err != nil && tt.pass {
 			t.Errorf("setScheme(%v): expected %v, errored: %v", tt.scheme, tt.expected, err)
 		}

--- a/pkg/annotations/validation_fake.go
+++ b/pkg/annotations/validation_fake.go
@@ -1,0 +1,54 @@
+package annotations
+
+type FakeValidator struct {
+	VpcId string
+	ResolveVPCValidateSubnetsDelegate func() error
+	ValidateSecurityGroupsDelegate func() error
+	ValidateCertARNDelegate func() error
+	ValidateInboundCidrsDelegate func() error
+	ValidateSchemeDelegate func() bool
+	ValidateWafAclIdDelegate func() error
+}
+
+func (fv FakeValidator) ResolveVPCValidateSubnets(a *Annotations) error {
+	if fv.ResolveVPCValidateSubnetsDelegate != nil {
+		return fv.ResolveVPCValidateSubnetsDelegate()
+	}
+	a.VPCID = &fv.VpcId
+	return nil
+}
+
+func (fv FakeValidator) ValidateSecurityGroups(a *Annotations) error {
+	if fv.ValidateSecurityGroupsDelegate != nil {
+		return fv.ValidateSecurityGroupsDelegate()
+	}
+	return nil
+}
+
+func (fv FakeValidator) ValidateCertARN(a *Annotations) error {
+	if fv.ValidateCertARNDelegate != nil {
+		return fv.ValidateCertARNDelegate()
+	}
+	return nil
+}
+
+func (fv FakeValidator) ValidateInboundCidrs(a *Annotations) error {
+	if fv.ValidateInboundCidrsDelegate != nil {
+		return fv.ValidateCertARNDelegate()
+	}
+	return nil
+}
+
+func (fv FakeValidator) ValidateScheme(a *Annotations, ingressNamespace, ingressName string) bool {
+	if fv.ValidateSchemeDelegate != nil {
+		return fv.ValidateSchemeDelegate()
+	}
+	return true
+}
+
+func (fv FakeValidator) ValidateWafAclId(a *Annotations) error {
+	if fv.ValidateWafAclIdDelegate != nil {
+		return fv.ValidateWafAclIdDelegate()
+	}
+	return nil
+}


### PR DESCRIPTION
…injection for unit testing.

Teased the stateful validation (configuration based and against AWS APIs) apart from annotation processing to make it easier to make changes to ALBIngress(es) by enabling unit testing with dependency injection before needing to run in a cluster.