### PR TITLE
Update iam-policy.json - Provide WebACL permissions

### DIFF
--- a/examples/iam-policy.json
+++ b/examples/iam-policy.json
@@ -53,7 +53,8 @@
                 "elasticloadbalancing:RemoveTags",
                 "elasticloadbalancing:SetIpAddressType",
                 "elasticloadbalancing:SetSecurityGroups",
-                "elasticloadbalancing:SetSubnets"
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:SetWebACL"
             ],
             "Resource": "*"
         },
@@ -62,6 +63,22 @@
             "Action": [
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "waf-regional:GetWebACLForResource"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "waf:GetWebACL",
+                "waf:AssociateWebACL",
+                "waf:DisassociateWebACL"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
The ingress controller pod was getting in a crash loop specifically asking for waf-regional:GetWebACLForResource access. I searched the code and found references to the other permissions - specifically found them here: https://github.com/coreos/alb-ingress-controller/blob/master/pkg/aws/waf/waf.go